### PR TITLE
fix(appreview-ios): AI 전송 사전동의 게이트 및 철회 설정 추가

### DIFF
--- a/NailClient/NailClient/Features/AIGeneration/Models/AITransferConsentStore.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Models/AITransferConsentStore.swift
@@ -1,0 +1,33 @@
+//
+//  AITransferConsentStore.swift
+//  NailClient
+//
+
+import Foundation
+
+struct AITransferConsentStore {
+    static let shared = AITransferConsentStore()
+
+    private let defaults: UserDefaults
+    private let consentKey: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        consentKey: String = "ai_transfer_consent_v1"
+    ) {
+        self.defaults = defaults
+        self.consentKey = consentKey
+    }
+
+    var hasConsent: Bool {
+        defaults.bool(forKey: consentKey)
+    }
+
+    func grantConsent() {
+        defaults.set(true, forKey: consentKey)
+    }
+
+    func revokeConsent() {
+        defaults.removeObject(forKey: consentKey)
+    }
+}

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -31,10 +31,12 @@ struct AINailGenerationView: View {
     @State private var lastAutoOpenedJobId: UUID?
     @State private var isResolvingDetailItem: Bool = false
     @State private var detailResolveAlert: DetailResolveAlert?
+    @State private var isConsentSheetPresented: Bool = false
     private let uploadCardSpacing: CGFloat = 12
     private let uploadCardHeight: CGFloat = 180
     private let uploadCardRowHeight: CGFloat = 212
     private let squareCropAspectRatio: CGSize = .init(width: 1, height: 1)
+    private let consentStore = AITransferConsentStore.shared
 
     @MainActor
     init() {
@@ -143,6 +145,9 @@ struct AINailGenerationView: View {
             selection: $viewModel.selectedReferencePhotoItem,
             matching: .images
         )
+        .sheet(isPresented: $isConsentSheetPresented) {
+            aiTransferConsentSheet
+        }
         .sheet(item: $selectedDetailItem) { item in
             FittedAIImageDetailSheet(
                 item: item,
@@ -559,10 +564,7 @@ struct AINailGenerationView: View {
 
     private var submitButtonBar: some View {
         Button {
-            Task {
-                await appViewModel.preparePushNotificationsForAIGeneration()
-                await viewModel.submitGeneration()
-            }
+            handleSubmitButtonTap()
         } label: {
             HStack(spacing: 8) {
                 if viewModel.isSubmitting {
@@ -593,6 +595,93 @@ struct AINailGenerationView: View {
             Rectangle()
                 .fill(AIGenerationDesignTokens.border)
                 .frame(height: 1)
+        }
+    }
+
+    private var aiTransferConsentSheet: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("AI 생성 기능을 사용하려면 데이터 전송 동의가 필요해요.")
+                    .font(.system(size: 19, weight: .bold))
+                    .foregroundStyle(AIGenerationDesignTokens.primaryText)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    consentRow(
+                        title: "전송 데이터",
+                        description: "손 사진, 디자인 사진, 생성 요청 관련 설정 값"
+                    )
+                    consentRow(
+                        title: "전송 대상",
+                        description: "OpenAI(이미지 생성 처리), Supabase(저장/전달 처리)"
+                    )
+                    consentRow(
+                        title: "전송 목적",
+                        description: "AI 네일 생성 결과 제공 및 요청 처리"
+                    )
+                }
+
+                if let privacyURL = AppConfig.privacyPolicyURL {
+                    Button("개인정보처리방침 보기") {
+                        openURL(privacyURL)
+                    }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(AIGenerationDesignTokens.accent)
+                }
+
+                Spacer(minLength: 0)
+
+                HStack(spacing: 10) {
+                    Button("동의 안 함") {
+                        isConsentSheetPresented = false
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(AIGenerationDesignTokens.accent)
+
+                    Button("동의하고 생성") {
+                        handleConsentApproved()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(AIGenerationDesignTokens.accent)
+                }
+            }
+            .padding(20)
+            .navigationTitle("AI 데이터 전송 동의")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func consentRow(title: String, description: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(AIGenerationDesignTokens.primaryText)
+            Text(description)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(AIGenerationDesignTokens.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func handleSubmitButtonTap() {
+        guard viewModel.canSubmit, !viewModel.isSubmitting else { return }
+        if consentStore.hasConsent {
+            submitGenerationFlow()
+            return
+        }
+        isConsentSheetPresented = true
+    }
+
+    private func handleConsentApproved() {
+        consentStore.grantConsent()
+        isConsentSheetPresented = false
+        submitGenerationFlow()
+    }
+
+    private func submitGenerationFlow() {
+        Task {
+            await appViewModel.preparePushNotificationsForAIGeneration()
+            await viewModel.submitGeneration()
         }
     }
 

--- a/NailClient/NailClient/Features/Settings/Views/SettingsView.swift
+++ b/NailClient/NailClient/Features/Settings/Views/SettingsView.swift
@@ -14,6 +14,9 @@ struct SettingsView: View {
     @State private var isDeletingAccount: Bool = false
     @State private var deleteErrorMessage: String?
     @State private var showMailFallbackAlert: Bool = false
+    @State private var hasAITransferConsent: Bool = false
+    @State private var showRevokeConsentConfirmAlert: Bool = false
+    private let consentStore = AITransferConsentStore.shared
 
     private var appVersionText: String {
         let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "-"
@@ -54,6 +57,28 @@ struct SettingsView: View {
                 }
             }
 
+            Section("AI 데이터 전송") {
+                HStack {
+                    Text("현재 동의 상태")
+                    Spacer()
+                    Text(hasAITransferConsent ? "동의됨" : "미동의")
+                        .foregroundStyle(.secondary)
+                }
+
+                if hasAITransferConsent {
+                    Button(role: .destructive) {
+                        showRevokeConsentConfirmAlert = true
+                    } label: {
+                        rowLabel("AI 데이터 전송 동의 철회")
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Text("AI 생성 시점에 다시 동의할 수 있어요.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("앱 정보") {
                 HStack {
                     Text("버전")
@@ -81,6 +106,9 @@ struct SettingsView: View {
         }
         .navigationTitle("설정")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            hasAITransferConsent = consentStore.hasConsent
+        }
         .disabled(isDeletingAccount)
         .alert("회원 탈퇴", isPresented: $showDeleteConfirmAlert) {
             Button("취소", role: .cancel) { }
@@ -121,6 +149,15 @@ struct SettingsView: View {
             Button("확인", role: .cancel) { }
         } message: {
             Text("고객센터 이메일: \(AppConfig.supportEmail)")
+        }
+        .alert("AI 데이터 전송 동의를 철회할까요?", isPresented: $showRevokeConsentConfirmAlert) {
+            Button("취소", role: .cancel) { }
+            Button("철회", role: .destructive) {
+                consentStore.revokeConsent()
+                hasAITransferConsent = false
+            }
+        } message: {
+            Text("철회 후에는 AI 생성 시 다시 동의해야 합니다.")
         }
     }
 


### PR DESCRIPTION
## 요약\n- AI 생성 직전 제3자 전송 고지/동의 시트 추가\n- 동의 없으면 생성 요청 차단\n- 설정 화면에서 동의 상태 확인 및 철회 지원\n\n## 변경 파일\n- NailClient/NailClient/Features/AIGeneration/Models/AITransferConsentStore.swift\n- NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift\n- NailClient/NailClient/Features/Settings/Views/SettingsView.swift\n\n## 검증\n- xcodebuild Debug iphonesimulator build 성공\n\nCloses #7