### PR TITLE
fix(ios-camera): 손 사진 촬영을 풀스크린 카메라 전환으로 변경

### DIFF
--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -154,7 +154,7 @@ struct AINailGenerationView: View {
             selection: $viewModel.selectedReferencePhotoItem,
             matching: .images
         )
-        .sheet(isPresented: $isHandCameraPresented) {
+        .fullScreenCover(isPresented: $isHandCameraPresented) {
             CameraCaptureView(
                 onCapture: { image in
                     handleCapturedHandPhoto(image)


### PR DESCRIPTION
## Summary
손 사진 촬영 프레젠테이션을 sheet에서 fullScreenCover로 변경해 카메라를 화면 전환형으로 표시합니다.

## Domain
client-app-ios

## Closes
Closes #15