### PR TITLE
fix(ios-feed): pull-to-refresh 안정화 및 취소(-999) 로그 레벨 정리

### DIFF
--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -491,6 +491,12 @@ final class EdgeAPIClient {
             (data, resp) = try await session.data(for: req)
         } catch {
             let redactedError = AppLog.truncate(AppLog.redact(String(describing: error)))
+            if Self.isCancellationLikeError(error) {
+                AppLog.api.debug(
+                    "\(AppLog.prefix(traceId, "API")) request cancelled <- \(method, privacy: .public) \(pathForLog, privacy: .public) error=\(redactedError, privacy: .public)"
+                )
+                throw error
+            }
             AppLog.api.error(
                 "\(AppLog.prefix(traceId, "API")) request failed <- \(method, privacy: .public) \(pathForLog, privacy: .public) error=\(redactedError, privacy: .public)"
             )
@@ -556,6 +562,20 @@ final class EdgeAPIClient {
 
         result = result.replacingOccurrences(of: "\\s", with: "", options: .regularExpression)
         return result.isEmpty ? nil : result
+    }
+
+    private static func isCancellationLikeError(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return true
+        }
+
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain
+            && nsError.code == URLError.cancelled.rawValue
     }
 }
 

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -42,6 +42,11 @@ final class FittedAIImagesViewModel: ObservableObject {
         case restoreOnCancellation
     }
 
+    private struct FetchPageResult {
+        let items: [FittedAIImageItem]
+        let nextCursor: String?
+    }
+
     private struct ListStateSnapshot {
         let items: [FittedAIImageItem]
         let nextCursor: String?
@@ -121,6 +126,8 @@ final class FittedAIImagesViewModel: ObservableObject {
     private var likedNextCursor: String?
     private var didLoadAll: Bool = false
     private var didLoadLiked: Bool = false
+    private var allLoadGeneration: Int = 0
+    private var likedLoadGeneration: Int = 0
 
     init(pageSize: Int = 20) {
         self.pageSize = max(1, min(pageSize, 50))
@@ -200,6 +207,7 @@ final class FittedAIImagesViewModel: ObservableObject {
         let filter = selectedFilter
         guard !isLoading(for: filter), !isLoadingMore(for: filter) else { return }
         guard let nextCursor = nextCursor(for: filter) else { return }
+        let requestGeneration = loadGeneration(for: filter)
 
         let currentItems = items(for: filter)
         guard let index = currentItems.firstIndex(where: { $0.id == currentItemID }) else { return }
@@ -211,10 +219,14 @@ final class FittedAIImagesViewModel: ObservableObject {
         defer { setLoadingMore(false, for: filter) }
 
         do {
-            try await fetchPage(filter: filter, cursor: nextCursor, replaceItems: false)
+            let result = try await fetchPage(filter: filter, cursor: nextCursor)
+            guard requestGeneration == loadGeneration(for: filter) else { return }
+            applyFetchResult(result, for: filter, replaceItems: false)
             setError(nil, for: filter)
             setDidLoad(true, for: filter)
         } catch {
+            guard requestGeneration == loadGeneration(for: filter) else { return }
+            if Self.isCancellationLikeError(error) { return }
             setError(Self.listLoadErrorMessage, for: filter)
             setDidLoad(true, for: filter)
         }
@@ -330,14 +342,37 @@ final class FittedAIImagesViewModel: ObservableObject {
         }
     }
 
+    private func loadGeneration(for filter: ListFilter) -> Int {
+        switch filter {
+        case .all:
+            return allLoadGeneration
+        case .liked:
+            return likedLoadGeneration
+        }
+    }
+
+    @discardableResult
+    private func bumpLoadGeneration(for filter: ListFilter) -> Int {
+        switch filter {
+        case .all:
+            allLoadGeneration += 1
+            return allLoadGeneration
+        case .liked:
+            likedLoadGeneration += 1
+            return likedLoadGeneration
+        }
+    }
+
     private func loadInitial(
         for filter: ListFilter,
         force: Bool,
         failureHandling: LoadFailureHandling = .standard
     ) async {
-        guard !isLoading(for: filter), !isLoadingMore(for: filter) else { return }
+        guard !isLoading(for: filter) else { return }
+        if !force, isLoadingMore(for: filter) { return }
         if didLoad(filter: filter) && !force { return }
         guard service != nil else { return }
+        let requestGeneration = force ? bumpLoadGeneration(for: filter) : loadGeneration(for: filter)
 
         let snapshot: ListStateSnapshot?
         if force && failureHandling == .restoreOnCancellation {
@@ -355,10 +390,13 @@ final class FittedAIImagesViewModel: ObservableObject {
         }
 
         do {
-            try await fetchPage(filter: filter, cursor: nil, replaceItems: true)
+            let result = try await fetchPage(filter: filter, cursor: nil)
+            guard requestGeneration == loadGeneration(for: filter) else { return }
+            applyFetchResult(result, for: filter, replaceItems: true)
             setError(nil, for: filter)
             setDidLoad(true, for: filter)
         } catch {
+            guard requestGeneration == loadGeneration(for: filter) else { return }
             if failureHandling == .restoreOnCancellation,
                let snapshot,
                Self.isCancellationLikeError(error) {
@@ -374,9 +412,8 @@ final class FittedAIImagesViewModel: ObservableObject {
 
     private func fetchPage(
         filter: ListFilter,
-        cursor: String?,
-        replaceItems: Bool
-    ) async throws {
+        cursor: String?
+    ) async throws -> FetchPageResult {
         guard let service else {
             throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
         }
@@ -387,18 +424,24 @@ final class FittedAIImagesViewModel: ObservableObject {
             likedOnly: filter.likedOnly
         )
 
-        let mappedItems = response.items.map(Self.makeItem)
+        return FetchPageResult(items: response.items.map(Self.makeItem), nextCursor: response.nextCursor)
+    }
+
+    private func applyFetchResult(
+        _ result: FetchPageResult,
+        for filter: ListFilter,
+        replaceItems: Bool
+    ) {
         if replaceItems {
-            setItems(mappedItems, for: filter)
+            setItems(result.items, for: filter)
         } else {
             let existing = Set(items(for: filter).map(\.jobId))
-            let appended = items(for: filter) + mappedItems.filter { !existing.contains($0.jobId) }
+            let appended = items(for: filter) + result.items.filter { !existing.contains($0.jobId) }
             setItems(appended, for: filter)
         }
 
         prefetchInitialThumbnails(for: filter)
-
-        setNextCursor(response.nextCursor, for: filter)
+        setNextCursor(result.nextCursor, for: filter)
     }
 
     private func prefetchInitialThumbnails(for filter: ListFilter) {

--- a/NailClient/NailClientTests/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/FittedAIImagesViewModelTests.swift
@@ -162,6 +162,94 @@ struct FittedAIImagesViewModelTests {
     }
 
     @Test
+    func refresh_URLError취소시_목록복원_에러미표시() async {
+        let initialID = UUID(uuidString: "76767676-7676-4767-8767-767676767676")!
+        let initialResponse = NailGenListResponse(
+            items: [makeItem(jobId: initialID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: "cursor-cancel"
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchResultsQueue = [
+            .success(initialResponse),
+            .failure(URLError(.cancelled))
+        ]
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+        #expect(viewModel.items.map(\.jobId) == [initialID])
+        #expect(viewModel.errorMessage == nil)
+
+        await viewModel.refresh()
+
+        #expect(viewModel.items.map(\.jobId) == [initialID])
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func refresh_중_진행중인loadMore결과는_무시하고_refresh결과를유지한다() async {
+        let initialID = UUID(uuidString: "12121212-1212-4121-8121-121212121212")!
+        let staleLoadMoreID = UUID(uuidString: "34343434-3434-4343-8343-343434343434")!
+        let refreshedID = UUID(uuidString: "56565656-5656-4565-8565-565656565656")!
+
+        let initialResponse = NailGenListResponse(
+            items: [makeItem(jobId: initialID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: "cursor-next"
+        )
+        let staleLoadMoreResponse = NailGenListResponse(
+            items: [makeItem(jobId: staleLoadMoreID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+        let refreshedResponse = NailGenListResponse(
+            items: [makeItem(jobId: refreshedID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+
+        let gate = AsyncGate()
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchHandler = { call, _, cursor, _ in
+            switch call {
+            case 1:
+                #expect(cursor == nil)
+                return initialResponse
+            case 2:
+                #expect(cursor == "cursor-next")
+                await gate.wait()
+                return staleLoadMoreResponse
+            case 3:
+                #expect(cursor == nil)
+                return refreshedResponse
+            default:
+                return refreshedResponse
+            }
+        }
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+        #expect(viewModel.items.map(\.jobId) == [initialID])
+
+        let loadMoreTask = Task {
+            await viewModel.loadMoreIfNeeded(currentItemID: initialID)
+        }
+
+        for _ in 0..<50 {
+            if service.fetchCallCount >= 2 { break }
+            await Task.yield()
+        }
+        #expect(service.fetchCallCount >= 2)
+
+        await viewModel.refresh()
+        await gate.open()
+        await loadMoreTask.value
+
+        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
     func refresh_일반에러시_기존정책유지() async {
         let initialID = UUID(uuidString: "77777777-7777-4777-8777-777777777777")!
         let initialResponse = NailGenListResponse(
@@ -281,6 +369,8 @@ private final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
     var deleteHandler: ((UUID) async throws -> NailGenDeleteResponse)?
     var deleteError: Error?
     var fetchResultsQueue: [Result<NailGenListResponse, Error>] = []
+    var fetchHandler: ((Int, Int, String?, Bool) async throws -> NailGenListResponse)?
+    private(set) var fetchCallCount: Int = 0
 
     init(listResponse: NailGenListResponse) {
         self.listResponse = listResponse
@@ -291,9 +381,11 @@ private final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
         cursor: String?,
         likedOnly: Bool
     ) async throws -> NailGenListResponse {
-        _ = limit
-        _ = cursor
-        _ = likedOnly
+        fetchCallCount += 1
+        let call = fetchCallCount
+        if let fetchHandler {
+            return try await fetchHandler(call, limit, cursor, likedOnly)
+        }
 
         if !fetchResultsQueue.isEmpty {
             return try fetchResultsQueue.removeFirst().get()
@@ -321,4 +413,22 @@ private final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
 private enum TestError: Error {
     case forced
     case unsupported
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
 }


### PR DESCRIPTION
## Summary
- `force refresh`가 `loadMore` 진행 중에도 무시되지 않도록 로딩 세대(generation) 기반 적용 정책을 추가했습니다.
- 오래된 응답(stale response)이 최신 refresh 결과를 덮어쓰지 않도록 discard 처리했습니다.
- `URLError.cancelled`/`-999`/`CancellationError`는 장애성 실패가 아니라 취소 이벤트로 분류해 debug 레벨로 로깅합니다.
- `FittedAIImagesViewModelTests`에 refresh 안정화/취소 처리 회귀 테스트를 추가했습니다.

## Domain
client-app-ios

## Closes
Closes #16
