### PR TITLE
fix(ios-feed): nail-gen-list refresh 200 보장 및 SWR 캐시/요청 단일화

### DIFF
--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -63,6 +63,16 @@ final class AppViewModel: ObservableObject {
         )
     }
 
+    private struct NailGenListCacheKey: Hashable {
+        let limit: Int
+        let likedOnly: Bool
+    }
+
+    private struct NailGenListCacheEntry {
+        let response: NailGenListResponse
+        let cachedAt: Date
+    }
+
     @Published private(set) var launchPhase: LaunchPhase = .booting
     @Published private(set) var route: Route = .login
     @Published private(set) var onboardingStyleImageURLs: [String: URL] = [:]
@@ -92,6 +102,10 @@ final class AppViewModel: ObservableObject {
     private var activeAIGenerationJobId: UUID?
     private var pendingPushTokenRegistration: (token: String, envHint: APNSEnvironmentHint)?
     private var pendingPushRoutePayload: PushNotificationRoutePayload?
+    private var nailGenListFirstPageCache: [NailGenListCacheKey: NailGenListCacheEntry] = [:]
+    private var nailGenListFirstPagePreloadTasks: [NailGenListCacheKey: Task<Void, Never>] = [:]
+
+    private let nailGenListCacheTTL: TimeInterval = 45
 
     init(
         authService: (any AuthServicing)? = nil,
@@ -271,6 +285,9 @@ final class AppViewModel: ObservableObject {
         onboardingPrefill = nextPrefill
         await syncPushTokenRegistrationIfPossible()
         route = nextRoute
+        if nextRoute == .home {
+            await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
+        }
         launchPhase = .ready
         flushPendingPushRouteIfPossible()
 
@@ -294,6 +311,9 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
+            if route == .home {
+                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
+            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithKakao failed: \(String(describing: error), privacy: .public)")
@@ -318,6 +338,9 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
+            if route == .home {
+                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
+            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithGoogle failed: \(String(describing: error), privacy: .public)")
@@ -342,6 +365,9 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
+            if route == .home {
+                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
+            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithApple failed: \(String(describing: error), privacy: .public)")
@@ -413,6 +439,9 @@ final class AppViewModel: ObservableObject {
             currentUser = updated.user
             onboardingPrefill = updated.needsOnboarding ? prefillFromUser(updated.user) : nil
             route = updated.needsOnboarding ? .onboarding : .home
+            if route == .home {
+                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
+            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.api.error("\(AppLog.prefix(traceId, "API")) completeOnboarding failed: \(String(describing: error), privacy: .public)")
@@ -633,6 +662,56 @@ final class AppViewModel: ObservableObject {
         return result.response
     }
 
+    func cachedNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) -> NailGenListResponse? {
+        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
+        guard let entry = nailGenListFirstPageCache[key] else { return nil }
+        let age = Date().timeIntervalSince(entry.cachedAt)
+        guard age <= nailGenListCacheTTL else {
+            nailGenListFirstPageCache[key] = nil
+            return nil
+        }
+        return entry.response
+    }
+
+    func setCachedNailGenerationFirstPage(
+        _ response: NailGenListResponse,
+        limit: Int,
+        likedOnly: Bool
+    ) {
+        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
+        nailGenListFirstPageCache[key] = NailGenListCacheEntry(
+            response: response,
+            cachedAt: Date()
+        )
+    }
+
+    func preloadNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async {
+        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
+        if cachedNailGenerationFirstPage(limit: limit, likedOnly: likedOnly) != nil {
+            return
+        }
+
+        if let existingTask = nailGenListFirstPagePreloadTasks[key] {
+            await existingTask.value
+            return
+        }
+
+        guard session != nil else { return }
+
+        let task = Task<Void, Never> { [weak self] in
+            guard let self else { return }
+            await self.runNailGenListFirstPagePreload(key: key)
+        }
+        nailGenListFirstPagePreloadTasks[key] = task
+        await task.value
+    }
+
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {
         let traceId = AppLog.makeErrorId()
         guard let session else {
@@ -713,6 +792,11 @@ final class AppViewModel: ObservableObject {
     }
 
     private func clearLocalSession() async {
+        for task in nailGenListFirstPagePreloadTasks.values {
+            task.cancel()
+        }
+        nailGenListFirstPagePreloadTasks.removeAll()
+        nailGenListFirstPageCache.removeAll()
         session = nil
         currentUser = nil
         onboardingPrefill = nil
@@ -729,6 +813,33 @@ final class AppViewModel: ObservableObject {
         pendingPushRoutePayload = nil
         pushAuthorizationState = .notDetermined
         await authService.clearLocalSession()
+    }
+
+    private func runNailGenListFirstPagePreload(key: NailGenListCacheKey) async {
+        defer { nailGenListFirstPagePreloadTasks[key] = nil }
+
+        do {
+            let response = try await fetchCompletedNailGenerationList(
+                limit: key.limit,
+                cursor: nil,
+                likedOnly: key.likedOnly
+            )
+            setCachedNailGenerationFirstPage(
+                response,
+                limit: key.limit,
+                likedOnly: key.likedOnly
+            )
+            let traceId = AppLog.makeErrorId()
+            AppLog.api.debug(
+                "\(AppLog.prefix(traceId, "API")) nail-gen-list preload_success likedOnly=\(key.likedOnly, privacy: .public) limit=\(key.limit, privacy: .public)"
+            )
+        } catch {
+            let traceId = AppLog.makeErrorId()
+            let redacted = AppLog.truncate(AppLog.redact(String(describing: error)))
+            AppLog.api.debug(
+                "\(AppLog.prefix(traceId, "API")) nail-gen-list preload_failed likedOnly=\(key.likedOnly, privacy: .public) limit=\(key.limit, privacy: .public) err=\(redacted, privacy: .public)"
+            )
+        }
     }
 
     private func bindPushManagerCallbacks() {

--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -493,7 +493,7 @@ final class EdgeAPIClient {
             let redactedError = AppLog.truncate(AppLog.redact(String(describing: error)))
             if Self.isCancellationLikeError(error) {
                 AppLog.api.debug(
-                    "\(AppLog.prefix(traceId, "API")) request cancelled <- \(method, privacy: .public) \(pathForLog, privacy: .public) error=\(redactedError, privacy: .public)"
+                    "\(AppLog.prefix(traceId, "API")) request_cancelled(expected) <- \(method, privacy: .public) \(pathForLog, privacy: .public) error=\(redactedError, privacy: .public)"
                 )
                 throw error
             }

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Combine
 import CoreGraphics
+import OSLog
 
 @MainActor
 protocol FittedAIImagesServicing: AnyObject {
@@ -18,6 +19,19 @@ protocol FittedAIImagesServicing: AnyObject {
         jobId: UUID,
         includeInputs: Bool
     ) async throws -> NailGenJobStatusResponse
+    func cachedNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) -> NailGenListResponse?
+    func setCachedNailGenerationFirstPage(
+        _ response: NailGenListResponse,
+        limit: Int,
+        likedOnly: Bool
+    )
+    func preloadNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse
     func deleteNailGeneration(jobId: UUID) async throws -> NailGenDeleteResponse
 }
@@ -33,6 +47,33 @@ extension FittedAIImagesServicing {
         _ = includeInputs
         throw EdgeAPIError(statusCode: -1, message: "상세 이미지 조회를 지원하지 않는 서비스입니다.", errorId: nil)
     }
+
+    func cachedNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) -> NailGenListResponse? {
+        _ = limit
+        _ = likedOnly
+        return nil
+    }
+
+    func setCachedNailGenerationFirstPage(
+        _ response: NailGenListResponse,
+        limit: Int,
+        likedOnly: Bool
+    ) {
+        _ = response
+        _ = limit
+        _ = likedOnly
+    }
+
+    func preloadNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async {
+        _ = limit
+        _ = likedOnly
+    }
 }
 
 @MainActor
@@ -43,8 +84,14 @@ final class FittedAIImagesViewModel: ObservableObject {
     }
 
     private struct FetchPageResult {
+        let response: NailGenListResponse
         let items: [FittedAIImageItem]
         let nextCursor: String?
+    }
+
+    private struct PageFetchKey: Hashable {
+        let filter: ListFilter
+        let cursor: String?
     }
 
     private struct ListStateSnapshot {
@@ -128,6 +175,7 @@ final class FittedAIImagesViewModel: ObservableObject {
     private var didLoadLiked: Bool = false
     private var allLoadGeneration: Int = 0
     private var likedLoadGeneration: Int = 0
+    private var inFlightPageFetchTasks: [PageFetchKey: Task<FetchPageResult, Error>] = [:]
 
     init(pageSize: Int = 20) {
         self.pageSize = max(1, min(pageSize, 50))
@@ -371,7 +419,7 @@ final class FittedAIImagesViewModel: ObservableObject {
         guard !isLoading(for: filter) else { return }
         if !force, isLoadingMore(for: filter) { return }
         if didLoad(filter: filter) && !force { return }
-        guard service != nil else { return }
+        guard let service else { return }
         let requestGeneration = force ? bumpLoadGeneration(for: filter) : loadGeneration(for: filter)
 
         let snapshot: ListStateSnapshot?
@@ -381,10 +429,37 @@ final class FittedAIImagesViewModel: ObservableObject {
             snapshot = nil
         }
 
-        setLoading(true, for: filter)
-        defer { setLoading(false, for: filter) }
+        let cachedFirstPage: FetchPageResult?
+        if !force,
+           let cached = service.cachedNailGenerationFirstPage(limit: pageSize, likedOnly: filter.likedOnly) {
+            cachedFirstPage = FetchPageResult(
+                response: cached,
+                items: cached.items.map(Self.makeItem),
+                nextCursor: cached.nextCursor
+            )
+        } else {
+            cachedFirstPage = nil
+        }
 
-        setNextCursor(nil, for: filter)
+        if let cachedFirstPage {
+            applyFetchResult(cachedFirstPage, for: filter, replaceItems: true)
+            setError(nil, for: filter)
+            setDidLoad(true, for: filter)
+        }
+
+        let shouldShowLoading = cachedFirstPage == nil
+        if shouldShowLoading {
+            setLoading(true, for: filter)
+        }
+        defer {
+            if shouldShowLoading {
+                setLoading(false, for: filter)
+            }
+        }
+
+        if force {
+            setNextCursor(nil, for: filter)
+        }
         if force {
             setItems([], for: filter)
         }
@@ -393,10 +468,60 @@ final class FittedAIImagesViewModel: ObservableObject {
             let result = try await fetchPage(filter: filter, cursor: nil)
             guard requestGeneration == loadGeneration(for: filter) else { return }
             applyFetchResult(result, for: filter, replaceItems: true)
+            service.setCachedNailGenerationFirstPage(
+                result.response,
+                limit: pageSize,
+                likedOnly: filter.likedOnly
+            )
             setError(nil, for: filter)
             setDidLoad(true, for: filter)
+            if force {
+                let traceId = AppLog.makeErrorId()
+                AppLog.api.info(
+                    "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(result.items.count, privacy: .public)"
+                )
+            }
         } catch {
             guard requestGeneration == loadGeneration(for: filter) else { return }
+            if force,
+               failureHandling == .restoreOnCancellation,
+               Self.isCancellationLikeError(error) {
+                do {
+                    let retriedResult = try await fetchPage(filter: filter, cursor: nil)
+                    guard requestGeneration == loadGeneration(for: filter) else { return }
+                    applyFetchResult(retriedResult, for: filter, replaceItems: true)
+                    service.setCachedNailGenerationFirstPage(
+                        retriedResult.response,
+                        limit: pageSize,
+                        likedOnly: filter.likedOnly
+                    )
+                    setError(nil, for: filter)
+                    setDidLoad(true, for: filter)
+                    let traceId = AppLog.makeErrorId()
+                    AppLog.api.info(
+                        "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(retriedResult.items.count, privacy: .public) attempt=retry_after_cancel"
+                    )
+                    return
+                } catch {
+                    guard requestGeneration == loadGeneration(for: filter) else { return }
+                    if let snapshot,
+                       Self.isCancellationLikeError(error) {
+                        restoreSnapshot(snapshot, for: filter)
+                        setError(nil, for: filter)
+                        return
+                    }
+                    setError(Self.listLoadErrorMessage, for: filter)
+                    setDidLoad(true, for: filter)
+                    return
+                }
+            }
+
+            if cachedFirstPage != nil && !force {
+                setError(nil, for: filter)
+                setDidLoad(true, for: filter)
+                return
+            }
+
             if failureHandling == .restoreOnCancellation,
                let snapshot,
                Self.isCancellationLikeError(error) {
@@ -414,17 +539,35 @@ final class FittedAIImagesViewModel: ObservableObject {
         filter: ListFilter,
         cursor: String?
     ) async throws -> FetchPageResult {
-        guard let service else {
-            throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
+        let key = PageFetchKey(filter: filter, cursor: cursor)
+        if let inFlightTask = inFlightPageFetchTasks[key] {
+            return try await inFlightTask.value
         }
 
-        let response = try await service.fetchCompletedNailGenerationList(
-            limit: pageSize,
-            cursor: cursor,
-            likedOnly: filter.likedOnly
-        )
+        let task = Task<FetchPageResult, Error> { @MainActor [weak self] in
+            guard let self else {
+                throw CancellationError()
+            }
+            guard let service = self.service else {
+                throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
+            }
 
-        return FetchPageResult(items: response.items.map(Self.makeItem), nextCursor: response.nextCursor)
+            let response = try await service.fetchCompletedNailGenerationList(
+                limit: self.pageSize,
+                cursor: cursor,
+                likedOnly: filter.likedOnly
+            )
+
+            return FetchPageResult(
+                response: response,
+                items: response.items.map(Self.makeItem),
+                nextCursor: response.nextCursor
+            )
+        }
+        inFlightPageFetchTasks[key] = task
+        defer { inFlightPageFetchTasks[key] = nil }
+
+        return try await task.value
     }
 
     private func applyFetchResult(

--- a/NailClient/NailClientTests/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/FittedAIImagesViewModelTests.swift
@@ -250,6 +250,144 @@ struct FittedAIImagesViewModelTests {
     }
 
     @Test
+    func loadIfNeeded_캐시히트시_즉시목록표시후_백그라운드재검증반영() async {
+        let cachedID = UUID(uuidString: "10101010-1010-4101-8101-101010101010")!
+        let refreshedID = UUID(uuidString: "20202020-2020-4202-8202-202020202020")!
+
+        let cachedResponse = NailGenListResponse(
+            items: [makeItem(jobId: cachedID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+        let refreshedResponse = NailGenListResponse(
+            items: [makeItem(jobId: refreshedID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+
+        let gate = AsyncGate()
+        let service = FittedAIImagesServiceSpy(listResponse: refreshedResponse)
+        service.cachedFirstPageResponses = [
+            .init(limit: 20, likedOnly: false): cachedResponse
+        ]
+        service.fetchHandler = { call, _, cursor, likedOnly in
+            #expect(call == 1)
+            #expect(cursor == nil)
+            #expect(likedOnly == false)
+            await gate.wait()
+            return refreshedResponse
+        }
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        let loadTask = Task {
+            await viewModel.loadIfNeeded()
+        }
+
+        for _ in 0..<50 {
+            if !viewModel.items.isEmpty {
+                break
+            }
+            await Task.yield()
+        }
+
+        #expect(viewModel.items.map(\.jobId) == [cachedID])
+        #expect(viewModel.errorMessage == nil)
+
+        await gate.open()
+        await loadTask.value
+
+        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.errorMessage == nil)
+        #expect(service.fetchCallCount == 1)
+    }
+
+    @Test
+    func refresh_취소후1회재시도성공시_최신결과로갱신한다() async {
+        let initialID = UUID(uuidString: "31313131-3131-4313-8313-313131313131")!
+        let refreshedID = UUID(uuidString: "41414141-4141-4414-8414-414141414141")!
+
+        let initialResponse = NailGenListResponse(
+            items: [makeItem(jobId: initialID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+        let refreshedResponse = NailGenListResponse(
+            items: [makeItem(jobId: refreshedID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchResultsQueue = [
+            .success(initialResponse),
+            .failure(URLError(.cancelled)),
+            .success(refreshedResponse)
+        ]
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+        #expect(viewModel.items.map(\.jobId) == [initialID])
+
+        await viewModel.refresh()
+
+        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.errorMessage == nil)
+        #expect(service.fetchCallCount == 3)
+    }
+
+    @Test
+    func loadMore_동시호출시_중복요청을억제한다() async {
+        let initialID = UUID(uuidString: "51515151-5151-4515-8515-515151515151")!
+        let appendedID = UUID(uuidString: "61616161-6161-4616-8616-616161616161")!
+
+        let initialResponse = NailGenListResponse(
+            items: [makeItem(jobId: initialID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: "cursor-next"
+        )
+        let loadMoreResponse = NailGenListResponse(
+            items: [makeItem(jobId: appendedID, parentJobId: nil, refinementTurn: 0)],
+            nextCursor: nil
+        )
+
+        let gate = AsyncGate()
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchHandler = { call, _, cursor, _ in
+            switch call {
+            case 1:
+                #expect(cursor == nil)
+                return initialResponse
+            case 2:
+                #expect(cursor == "cursor-next")
+                await gate.wait()
+                return loadMoreResponse
+            default:
+                return loadMoreResponse
+            }
+        }
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+
+        let first = Task { await viewModel.loadMoreIfNeeded(currentItemID: initialID) }
+        let second = Task { await viewModel.loadMoreIfNeeded(currentItemID: initialID) }
+
+        for _ in 0..<50 {
+            if service.fetchCallCount >= 2 {
+                break
+            }
+            await Task.yield()
+        }
+
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(service.fetchCallCount == 2)
+        #expect(viewModel.items.map(\.jobId) == [initialID, appendedID])
+    }
+
+    @Test
     func refresh_일반에러시_기존정책유지() async {
         let initialID = UUID(uuidString: "77777777-7777-4777-8777-777777777777")!
         let initialResponse = NailGenListResponse(
@@ -365,11 +503,18 @@ struct FittedAIImagesViewModelTests {
 
 @MainActor
 private final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
+    struct CacheKey: Hashable {
+        let limit: Int
+        let likedOnly: Bool
+    }
+
     let listResponse: NailGenListResponse
     var deleteHandler: ((UUID) async throws -> NailGenDeleteResponse)?
     var deleteError: Error?
     var fetchResultsQueue: [Result<NailGenListResponse, Error>] = []
     var fetchHandler: ((Int, Int, String?, Bool) async throws -> NailGenListResponse)?
+    var cachedFirstPageResponses: [CacheKey: NailGenListResponse] = [:]
+    var preloadCallCount: Int = 0
     private(set) var fetchCallCount: Int = 0
 
     init(listResponse: NailGenListResponse) {
@@ -392,6 +537,30 @@ private final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
         }
 
         return listResponse
+    }
+
+    func cachedNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) -> NailGenListResponse? {
+        cachedFirstPageResponses[.init(limit: limit, likedOnly: likedOnly)]
+    }
+
+    func setCachedNailGenerationFirstPage(
+        _ response: NailGenListResponse,
+        limit: Int,
+        likedOnly: Bool
+    ) {
+        cachedFirstPageResponses[.init(limit: limit, likedOnly: likedOnly)] = response
+    }
+
+    func preloadNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async {
+        _ = limit
+        _ = likedOnly
+        preloadCallCount += 1
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {


### PR DESCRIPTION
## Summary
- AppViewModel에 nail-gen-list first-page 인메모리 캐시(TTL 45s)와 로그인 직후 프리로드를 추가했습니다.
- FittedAIImagesViewModel에 SWR(캐시 즉시표시 + 백그라운드 재검증), 요청 single-flight, refresh 취소 시 1회 자동 재시도를 적용했습니다.
- 취소(-999) 로그 문구를 request_cancelled(expected)로 정리하고 관련 단위 테스트를 보강했습니다.

## Domain
client-app-ios

## Closes
Closes #22