### PR TITLE
[Task] 협업정책: AGENTS/GitHub 운영 규칙 개편

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug Report
+description: 버그 제보 및 장애 리포트
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        재현 가능한 정보 위주로 작성해주세요.
+        민감정보(토큰, 개인정보, 내부 키)는 제거 후 첨부하세요.
+
+  - type: checkboxes
+    id: precheck
+    attributes:
+      label: 사전 확인
+      options:
+        - label: 기존 이슈를 검색했고 중복이 아님을 확인했습니다.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 요약
+      description: 어떤 문제가 발생했는지 한두 문장으로 작성해주세요.
+      placeholder: 예) 예약 상세 화면 진입 시 앱이 즉시 종료됩니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 절차
+      description: 재현 순서를 단계별로 작성해주세요.
+      placeholder: |
+        1. 앱 실행
+        2. 마이페이지 탭 이동
+        3. 예약 내역 선택
+        4. 크래시 발생
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 결과
+      placeholder: 예) 예약 상세 화면이 정상적으로 렌더링된다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 결과
+      placeholder: 예) 로딩 직후 앱이 종료된다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 환경 정보
+      description: 가능한 한 구체적으로 적어주세요.
+      value: |
+        - App version:
+        - iOS version:
+        - Device:
+        - Network:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: 영향도
+      options:
+        - P0 (서비스 핵심 기능 완전 불가)
+        - P1 (주요 기능 심각 장애)
+        - P2 (우회 가능, 중간 영향)
+        - P3 (경미한 문제)
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 증거 자료
+      description: 로그, 스택트레이스, 스크린샷 링크를 첨부해주세요.
+      render: shell
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 관련 링크
+      description: 관련 Notion/PR/Issue/문서 링크를 남겨주세요.
+      placeholder: |
+        - Notion:
+        - Related Issue:
+        - Related PR:

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -91,8 +91,9 @@ body:
     id: references
     attributes:
       label: 관련 링크
-      description: 관련 Notion/PR/Issue/문서 링크를 남겨주세요.
+      description: 관련 GitHub 이슈/PR/문서 링크를 남겨주세요.
       placeholder: |
-        - Notion:
         - Related Issue:
         - Related PR:
+        - Shared Schema Request Issue (DB/API/요구사항 변경 시):
+        - Docs/Logs/Screenshot:

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature Request
+description: 기능 제안 및 개선 요청
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        해결하려는 문제와 기대 효과를 중심으로 작성해주세요.
+
+  - type: checkboxes
+    id: precheck
+    attributes:
+      label: 사전 확인
+      options:
+        - label: 기존 이슈를 검색했고 중복이 아님을 확인했습니다.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 배경/문제
+      description: 현재 어떤 불편 또는 한계가 있는지 작성해주세요.
+      placeholder: 예) 네일샵 필터 기준이 부족해 원하는 샵을 찾기 어렵다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 제안 내용
+      description: 원하는 동작/해결안을 구체적으로 작성해주세요.
+      placeholder: 예) 지역/가격/리뷰/당일예약 가능 여부 필터를 추가한다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 수용 기준 (Acceptance Criteria)
+      description: 완료 여부를 판단할 수 있는 기준을 작성해주세요.
+      placeholder: |
+        - [ ] 필터 UI에서 지역/가격/리뷰/당일예약 옵션 선택 가능
+        - [ ] 필터 적용 시 목록 결과가 즉시 갱신됨
+        - [ ] 필터 초기화 버튼 동작
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 범위 (In scope / Out of scope)
+      placeholder: |
+        In scope:
+        -
+
+        Out of scope:
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 관련 링크
+      description: 관련 Notion/디자인/문서/회의록 링크를 남겨주세요.
+      placeholder: |
+        - Notion Spec:
+        - Figma:
+        - Related Docs:
+
+  - type: checkboxes
+    id: notion-alignment
+    attributes:
+      label: Notion 정합성 확인
+      description: DB/API/요구사항 변경이 있는 경우 필수
+      options:
+        - label: Notion 기준 문서와 대조했고, 변경 포인트를 본문 링크에 남겼습니다.
+          required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -63,17 +63,10 @@ body:
     id: references
     attributes:
       label: 관련 링크
-      description: 관련 Notion/디자인/문서/회의록 링크를 남겨주세요.
+      description: 관련 GitHub/디자인/문서 링크를 남겨주세요.
       placeholder: |
-        - Notion Spec:
+        - Related Issue:
+        - Related PR:
+        - Shared Schema Request Issue (DB/API/요구사항 변경 시):
         - Figma:
         - Related Docs:
-
-  - type: checkboxes
-    id: notion-alignment
-    attributes:
-      label: Notion 정합성 확인
-      description: DB/API/요구사항 변경이 있는 경우 필수
-      options:
-        - label: Notion 기준 문서와 대조했고, 변경 포인트를 본문 링크에 남겼습니다.
-          required: false

--- a/.github/ISSUE_TEMPLATE/03_task.yml
+++ b/.github/ISSUE_TEMPLATE/03_task.yml
@@ -1,0 +1,59 @@
+name: Task
+description: 리팩토링/문서/테스트/운영 작업
+title: "[Task] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        기능 추가가 아닌 실행 작업(정리/개선/운영)을 위한 템플릿입니다.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: 작업 목적
+      placeholder: 예) 로그인 모듈 에러 처리 경로를 단순화해 유지보수성을 높인다.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: 도메인
+      options:
+        - client-app-ios
+        - infra
+        - docs
+        - ci
+    validations:
+      required: true
+
+  - type: textarea
+    id: checklist
+    attributes:
+      label: 작업 체크리스트
+      placeholder: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: 완료 조건 (Definition of Done)
+      placeholder: |
+        - [ ] 코드/문서 반영 완료
+        - [ ] 필요한 빌드/테스트 실행 완료
+        - [ ] PR에서 해당 이슈를 Closes로 연결
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 관련 링크
+      placeholder: |
+        - Related Issue:
+        - Related PR:
+        - Docs/Notion:

--- a/.github/ISSUE_TEMPLATE/03_task.yml
+++ b/.github/ISSUE_TEMPLATE/03_task.yml
@@ -56,4 +56,5 @@ body:
       placeholder: |
         - Related Issue:
         - Related PR:
-        - Docs/Notion:
+        - Shared Schema Request Issue (DB/API/요구사항 변경 시):
+        - Docs:

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,4 +1,0 @@
-## Summary
-
-## Domain
-client-app-ios

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,26 @@
 ## Summary
 
-## Domain
-client-app-ios
-
 ## Closes
 Closes #<issue-number>
+
+## Scope (In scope / Out of scope)
+In scope:
+- 
+
+Out of scope:
+- 
+
+## Validation Results
+- Build:
+- Unit tests (if needed):
+- UI tests (if needed):
+- 실행 명령/결과:
+  - 
+
+## Risk & Rollback
+- Risk:
+- Rollback:
+
+## Shared Schema Request Issue
+- N/A (DB 스키마 변경 없음)
+- 또는 https://github.com/todays-nail/shared-schema/issues/<number>

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -1,0 +1,122 @@
+name: policy-gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  policy-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch and PR policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("pull_request 컨텍스트를 찾지 못했습니다.");
+              return;
+            }
+
+            const headRef = pr.head.ref;
+            const baseRef = pr.base.ref;
+            const body = pr.body || "";
+            const errors = [];
+
+            const branchPatterns = {
+              feature: /^feature\/\d+-[a-z0-9][a-z0-9-]*$/,
+              bugfix: /^bugfix\/\d+-[a-z0-9][a-z0-9-]*$/,
+              task: /^task\/\d+-[a-z0-9][a-z0-9-]*$/,
+              release: /^release\/ios-v\d+(?:\.\d+)*\+\d+$/,
+              hotfix: /^hotfix\/\d+-[a-z0-9][a-z0-9-]*$/
+            };
+
+            let branchType = null;
+            for (const candidate of Object.keys(branchPatterns)) {
+              if (headRef.startsWith(`${candidate}/`)) {
+                branchType = candidate;
+                break;
+              }
+            }
+
+            if (!branchType) {
+              errors.push(
+                "브랜치 접두어는 feature/, bugfix/, task/, release/, hotfix/ 중 하나여야 합니다."
+              );
+            } else {
+              const pattern = branchPatterns[branchType];
+              if (!pattern.test(headRef)) {
+                errors.push(
+                  `브랜치명 형식이 올바르지 않습니다: ${headRef}`
+                );
+              }
+
+              const expectedBase = ["feature", "bugfix", "task"].includes(branchType)
+                ? "develop"
+                : "main";
+              if (baseRef !== expectedBase) {
+                errors.push(
+                  `${branchType} 브랜치는 ${expectedBase} 브랜치로만 PR을 생성할 수 있습니다. (현재 base: ${baseRef})`
+                );
+              }
+            }
+
+            if (!/\bCloses\s+#\d+\b/i.test(body)) {
+              errors.push("PR 본문에 `Closes #<issue-number>`를 반드시 포함해야 합니다.");
+            }
+
+            const requiredHeaders = [
+              "## Summary",
+              "## Closes",
+              "## Scope (In scope / Out of scope)",
+              "## Validation Results",
+              "## Risk & Rollback",
+              "## Shared Schema Request Issue"
+            ];
+
+            for (const header of requiredHeaders) {
+              if (!body.includes(header)) {
+                errors.push(`PR 본문 필수 섹션이 누락되었습니다: ${header}`);
+              }
+            }
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              }
+            );
+
+            const dbTouched = files.some((file) =>
+              file.filename.startsWith("infra/supabase/migrations/") ||
+              file.filename.startsWith("infra/supabase/functions/")
+            );
+
+            if (dbTouched) {
+              const sharedSchemaIssuePattern =
+                /https:\/\/github\.com\/todays-nail\/shared-schema\/issues\/\d+/i;
+              if (!sharedSchemaIssuePattern.test(body)) {
+                errors.push(
+                  "DB 관련 파일 변경 시 PR 본문에 shared-schema 요청 이슈 링크(https://github.com/todays-nail/shared-schema/issues/<number>)를 포함해야 합니다."
+                );
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.map((error, index) => `${index + 1}. ${error}`).join("\n"));
+              return;
+            }
+
+            core.info("policy-gate 검증을 통과했습니다.");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,23 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 - Prefer Swift Package Manager. Do not introduce CocoaPods/Carthage unless the repo already uses them (ask first).
 - Ask before changing signing/bundle identifiers/capabilities or introducing new production dependencies.
 
+## Issue Conventions
+
+- 모든 개발 작업은 이슈 생성 후 진행한다. (단순 오탈자/문구 수정 등 10분 이내 경미 작업은 예외 가능)
+- 이슈 타입은 `Bug`, `Feature`, `Task` 3가지를 기본으로 사용한다.
+- 이슈 제목 규칙:
+  - `[Bug] <영역>: <증상>`
+  - `[Feature] <영역>: <요구사항/개선점>`
+  - `[Task] <영역>: <작업 내용>`
+- 이슈 본문 필수 정보:
+  - 배경/문제
+  - 기대 결과 또는 수용 기준(AC)
+  - 범위(In scope / Out of scope)
+  - 관련 링크(화면, API, 문서, 로그, 스크린샷 등)
+- 버그 이슈는 반드시 `재현 절차`, `기대 결과`, `실제 결과`, `환경(OS/기기/앱 버전)`을 포함한다.
+- DB/API/요구사항 변경 이슈는 Notion 기준 문서 링크와 정합성 체크 포인트를 본문에 남긴다.
+- PR은 반드시 관련 이슈를 연결한다. (`Closes #<issue-number>`)
+
 ## Release Tag Policy
 
 - Release 기준은 브랜치가 아닌 버전 태그를 사용한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,32 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
   - 범위(In scope / Out of scope)
   - 관련 링크(화면, API, 문서, 로그, 스크린샷 등)
 - 버그 이슈는 반드시 `재현 절차`, `기대 결과`, `실제 결과`, `환경(OS/기기/앱 버전)`을 포함한다.
-- DB/API/요구사항 변경 이슈는 Notion 기준 문서 링크와 정합성 체크 포인트를 본문에 남긴다.
+- DB 스키마 변경은 `todays-nail/shared-schema` 저장소에서만 관리하고, 이 저장소에는 sync 결과만 반영한다.
+- DB/API/요구사항 변경 이슈는 `shared-schema` 요청 이슈 링크와 정합성 체크 포인트를 본문에 남긴다.
 - PR은 반드시 관련 이슈를 연결한다. (`Closes #<issue-number>`)
+
+## Branch Strategy (GitFlow Lite)
+
+- 장기 브랜치는 `main`, `develop` 두 개만 사용한다.
+- 기본 개발 루트 브랜치는 `develop`이다.
+- 일반 작업 브랜치:
+  - `feature/<issue-number>-<slug>`
+  - `bugfix/<issue-number>-<slug>`
+  - `task/<issue-number>-<slug>`
+- 일반 작업 브랜치는 `develop`에서 분기하고 `develop`으로 PR을 생성한다.
+- 릴리즈 브랜치: `release/ios-v<MARKETING_VERSION>+<CURRENT_PROJECT_VERSION>` 형식으로 `develop`에서 분기하고 `main`으로 PR을 생성한다.
+- 긴급 수정 브랜치: `hotfix/<issue-number>-<slug>` 형식으로 `main`에서 분기하고 `main`으로 PR을 생성한다.
+- 기본 머지 방식은 `Squash merge`를 사용한다.
+- `main`에 반영된 릴리즈/핫픽스 변경사항은 반드시 `develop`으로 역머지(back-merge) PR을 생성한다.
+
+## Definition of Done (GitHub Only)
+
+- PR 본문에 `Closes #<issue-number>`를 반드시 포함한다.
+- PR 본문에 `Summary`, `Scope (In scope / Out of scope)`, `Validation Results`, `Risk & Rollback` 섹션을 반드시 작성한다.
+- 검증 결과에는 실제 실행한 빌드/테스트 명령과 결과를 명시한다.
+- DB 스키마 변경이 포함된 PR은 `https://github.com/todays-nail/shared-schema/issues/<number>` 링크를 반드시 포함한다.
+- 브랜치 보호 규칙에서 `main`, `develop`에 `policy-gate`, `Supabase Schema Validation`, `ios-warning-gate`를 필수 체크로 설정하고 direct push를 차단한다.
+- 관련 이슈/PR 링크는 GitHub 기준으로 남기고, 완료 기준은 GitHub 이슈/PR 상태로 판정한다.
 
 ## Release Tag Policy
 
@@ -40,12 +64,6 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 - iOS 릴리즈 태그 형식: `ios/v<MARKETING_VERSION>+<CURRENT_PROJECT_VERSION>` (예: `ios/v1.0+6`).
 - 태그는 `main`에 머지된 릴리즈 커밋에 annotated tag로 생성한다.
 - 기존 날짜 태그(`rel-*`)는 레거시 참조용으로만 유지하고 신규 릴리즈 기준으로 사용하지 않는다.
-
-## Notion Alignment (Required)
-
-- DB/API/요구사항 변경 작업 전 Notion 기준 문서(`🧩 기능 명세`, `🙏 요구사항 명세서`, `🚀 MVP`, `📑 시나리오`, `🗒️ 기능 구현`)를 먼저 확인한다.
-- 코드 변경과 문서 변경은 같은 작업 사이클에서 함께 반영해 정합성을 유지한다.
-- PR 설명에는 참조한 Notion 링크와 정합성 체크 결과(무엇을 대조했고 어떤 결론인지)를 필수로 남긴다.
 
 ## Project Discovery (Do This First)
 


### PR DESCRIPTION
## Summary
- AGENTS 정책을 Notion 의무에서 GitHub Issue/PR 중심 운영으로 전환했습니다.
- 개발 루트 브랜치를 `develop`으로 고정한 GitFlow Lite 규칙을 추가했습니다.
- Issue/PR 템플릿과 CI policy-gate를 추가해 규칙을 자동 검증하도록 구성했습니다.

## Closes
Closes #36

## Scope (In scope / Out of scope)
In scope:
- AGENTS.md 정책 개편
- Bug/Feature/Task 이슈 템플릿 개편
- PR 템플릿 강화
- policy-gate 워크플로우 신규 추가

Out of scope:
- GitHub branch protection 설정값 실제 변경(레포 설정 작업)
- 앱 런타임 로직 변경

## Validation Results
- Build: N/A (문서/워크플로우 정책 변경)
- Unit tests (if needed): N/A
- UI tests (if needed): N/A
- 실행 명령/결과:
  - `ruby -e 'require "yaml"; ...'` (YAML 파싱 점검) 통과
  - `rg -n "Notion Alignment (Required)|Notion 기준 문서|notion-alignment|Notion Spec|Docs/Notion|관련 Notion" ...` (잔존 문구 점검) 매치 없음

## Risk & Rollback
- Risk:
  - 기존에 `chore/*` 브랜치를 사용하던 팀원이 있으면 policy-gate 실패 가능
- Rollback:
  - `policy-gate.yml` 규칙 완화 또는 브랜치 정책 문구를 이전 버전으로 되돌리는 리버트 커밋 적용

## Shared Schema Request Issue
- N/A (DB 스키마 변경 없음)
