### PR TITLE
refactor(architecture): UI 계층 경계 정리와 프리뷰 안정화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,9 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 - Swift concurrency: prefer `async/await`; keep UI updates on the main actor.
 - Avoid force unwraps and forced casts unless you can justify safety locally.
 - Prefer small, testable units. Keep business logic out of views.
+- Prefer the simplest implementation that satisfies the current requirement.
+- Remove duplication only when it materially reduces maintenance cost.
+- Avoid abstractions or generalizations for unproven future needs.
 
 ## Review Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 - Allowed `type`: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`.
 - Disallowed `type`: `ci`, `perf`, `revert`.
 - Keep `subject` concise and do not end with a period.
+- Write the `subject` in Korean.
 - If commit body is present, write it in Korean bullet format only.
 - Commit body bullet count must be between 1 and 4.
 - Footer should include `Refs: #<issue-number>` or `Closes: #<issue-number>` when applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 - Do not run `swift test` for iOS app test runs. Use `xcodebuild` + a simulator instead.
 - List schemes: `xcodebuild -list -project NailClient/NailClient.xcodeproj`
 - To avoid parallel build collisions, do not share one DerivedData path that creates a common `build.db` lock. Use a dedicated `-derivedDataPath` per task.
+- Within the same task/thread, prefer reusing the same `-derivedDataPath` (and optionally `-clonedSourcePackagesDirPath`) across repeated builds so Xcode can reuse build and package caches.
 - If concurrent builds are required, use different `-derivedDataPath` values or run builds sequentially.
 - `scripts/ios-warning-gate.sh` also uses a temporary `-derivedDataPath` for Release/Debug builds to reduce global DerivedData accumulation.
 

--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -190,6 +190,7 @@ final class AppViewModel: ObservableObject {
         aiGenerationIsRunning = false
         aiGenerationProgressMessage = "생성이 완료되었습니다."
         activeAIGenerationJobId = nil
+        refreshNailGenerationFirstPageCache(likedOnly: false)
     }
 
     func failAIGeneration(jobId: UUID?, message: String) {
@@ -710,6 +711,40 @@ final class AppViewModel: ObservableObject {
         }
         nailGenListFirstPagePreloadTasks[key] = task
         await task.value
+    }
+
+    func invalidateNailGenerationFirstPageCache(likedOnly: Bool? = nil) {
+        let cacheKeys = nailGenListFirstPageCache.keys.filter { key in
+            guard let likedOnly else { return true }
+            return key.likedOnly == likedOnly
+        }
+        for key in cacheKeys {
+            nailGenListFirstPageCache[key] = nil
+        }
+
+        let taskKeys = nailGenListFirstPagePreloadTasks.keys.filter { key in
+            guard let likedOnly else { return true }
+            return key.likedOnly == likedOnly
+        }
+        for key in taskKeys {
+            nailGenListFirstPagePreloadTasks[key]?.cancel()
+            nailGenListFirstPagePreloadTasks[key] = nil
+        }
+    }
+
+    func refreshNailGenerationFirstPageCache(
+        likedOnly: Bool,
+        limit: Int = 20
+    ) {
+        invalidateNailGenerationFirstPageCache(likedOnly: likedOnly)
+        guard session != nil else { return }
+
+        Task { [weak self] in
+            await self?.preloadNailGenerationFirstPage(
+                limit: limit,
+                likedOnly: likedOnly
+            )
+        }
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {

--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -1059,7 +1059,6 @@ final class AppViewModel: ObservableObject {
     }
 }
 
-#if DEBUG
 extension AppViewModel {
     static func preview(
         route: Route = .home,
@@ -1430,4 +1429,3 @@ private actor PreviewAuthService: AuthServicing {
         )
     }
 }
-#endif

--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -107,6 +107,10 @@ final class AppViewModel: ObservableObject {
 
     private let nailGenListCacheTTL: TimeInterval = 45
 
+    static var isRunningForPreviews: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
     init(
         authService: (any AuthServicing)? = nil,
         pushManager: (any PushNotificationManaging)? = nil,
@@ -207,6 +211,7 @@ final class AppViewModel: ObservableObject {
     }
 
     func preparePushNotificationsForAIGeneration() async {
+        guard !Self.isRunningForPreviews else { return }
         let granted = await pushManager.requestAuthorizationIfNeeded()
         await refreshPushAuthorizationState()
         guard granted else { return }
@@ -222,11 +227,19 @@ final class AppViewModel: ObservableObject {
     }
 
     func refreshPushAuthorizationState() async {
+        guard !Self.isRunningForPreviews else { return }
         pushAuthorizationState = await pushManager.fetchAuthorizationState()
     }
 
     func start() async {
         guard !didStart else { return }
+        guard !Self.isRunningForPreviews else {
+            didStart = true
+            if launchPhase != .ready {
+                launchPhase = .ready
+            }
+            return
+        }
         didStart = true
 
         if ProcessInfo.processInfo.arguments.contains("--uitesting-route-login") {
@@ -379,6 +392,7 @@ final class AppViewModel: ObservableObject {
     }
 
     func refreshOnboardingStyleAssets(force: Bool = false) async {
+        guard !Self.isRunningForPreviews else { return }
         if !force,
            let fetchedAt = onboardingStyleAssetsFetchedAt,
            Date().timeIntervalSince(fetchedAt) < 300 {
@@ -1044,3 +1058,376 @@ final class AppViewModel: ObservableObject {
         launchPhase = .ready
     }
 }
+
+#if DEBUG
+extension AppViewModel {
+    static func preview(
+        route: Route = .home,
+        launchPhase: LaunchPhase = .ready,
+        currentUser: AppUser? = .preview(),
+        session: AppSession? = AppSession(accessToken: "preview-access", refreshToken: "preview-refresh"),
+        onboardingPrefill: OnboardingPrefill? = nil,
+        selectedMainTab: MainTab = .home,
+        onboardingStyleImageURLs: [String: URL] = [:],
+        pushAuthorizationState: PushAuthorizationState = .allowed
+    ) -> AppViewModel {
+        let authService = PreviewAuthService(
+            session: session,
+            user: currentUser,
+            onboardingPrefill: onboardingPrefill
+        )
+        let pushManager = PreviewPushNotificationManager(
+            authorizationState: pushAuthorizationState
+        )
+        let viewModel = AppViewModel(
+            authService: authService,
+            pushManager: pushManager,
+            launchTiming: .init(
+                minimumSplashDuration: .zero,
+                autoLoginTimeout: .seconds(1)
+            )
+        )
+        viewModel.launchPhase = launchPhase
+        viewModel.route = route
+        viewModel.currentUser = currentUser
+        viewModel.session = session
+        viewModel.onboardingPrefill = onboardingPrefill
+        viewModel.selectedMainTab = selectedMainTab
+        viewModel.onboardingStyleImageURLs = onboardingStyleImageURLs
+        viewModel.pushAuthorizationState = pushAuthorizationState
+        viewModel.didStart = true
+        viewModel.didLogFirstFrame = true
+        return viewModel
+    }
+}
+
+@MainActor
+private final class PreviewPushNotificationManager: PushNotificationManaging {
+    var latestDeviceTokenHex: String?
+    var latestEnvironmentHint: APNSEnvironmentHint = .sandbox
+    var onDeviceTokenUpdated: ((String, APNSEnvironmentHint) -> Void)?
+    var onNotificationTapped: ((PushNotificationRoutePayload) -> Void)?
+
+    private let authorizationState: PushAuthorizationState
+
+    init(authorizationState: PushAuthorizationState) {
+        self.authorizationState = authorizationState
+    }
+
+    func configure() {}
+
+    func requestAuthorizationIfNeeded() async -> Bool {
+        authorizationState == .allowed
+    }
+
+    func fetchAuthorizationState() async -> PushAuthorizationState {
+        authorizationState
+    }
+
+    func handleDidRegisterForRemoteNotifications(deviceToken: Data) {}
+
+    func handleDidFailToRegisterForRemoteNotifications(error: Error) {}
+
+    func handleLaunchRemoteNotification(userInfo: [AnyHashable: Any]) {}
+}
+
+private actor PreviewAuthService: AuthServicing {
+    private var session: AppSession?
+    private var user: AppUser?
+    private let onboardingPrefill: OnboardingPrefill?
+    private var nailGenerationItems: [NailGenListItemResponse] = []
+
+    init(
+        session: AppSession?,
+        user: AppUser?,
+        onboardingPrefill: OnboardingPrefill?
+    ) {
+        self.session = session
+        self.user = user
+        self.onboardingPrefill = onboardingPrefill
+    }
+
+    func tryAutoLogin(traceId: String, timeout: Duration) async throws -> AuthResult? {
+        _ = traceId
+        _ = timeout
+        guard let session, let user else { return nil }
+        return AuthResult(
+            session: session,
+            user: user,
+            needsOnboarding: onboardingPrefill != nil,
+            onboardingPrefill: onboardingPrefill
+        )
+    }
+
+    func signInWithKakao(traceId: String) async throws -> AuthResult {
+        try await previewAuthResult(traceId: traceId)
+    }
+
+    func signInWithGoogle(traceId: String) async throws -> AuthResult {
+        try await previewAuthResult(traceId: traceId)
+    }
+
+    func signInWithApple(traceId: String) async throws -> AuthResult {
+        try await previewAuthResult(traceId: traceId)
+    }
+
+    func completeOnboarding(
+        traceId: String,
+        session: AppSession,
+        nickname: String,
+        profileImageURL: String?
+    ) async throws -> (user: AppUser, needsOnboarding: Bool, session: AppSession) {
+        _ = traceId
+        let updatedUser = AppUser(
+            id: user?.id ?? UUID(),
+            role: user?.role,
+            nickname: nickname,
+            profileImageURL: profileImageURL,
+            defaultRegionID: user?.defaultRegionID,
+            defaultRegionLabel: user?.defaultRegionLabel,
+            defaultServiceRegionID: user?.defaultServiceRegionID,
+            createdAt: user?.createdAt,
+            updatedAt: Date()
+        )
+        self.session = session
+        self.user = updatedUser
+        return (updatedUser, false, session)
+    }
+
+    func updateMyProfile(
+        traceId: String,
+        session: AppSession,
+        nickname: String,
+        profileImageURL: String?
+    ) async throws -> (user: AppUser, session: AppSession) {
+        _ = traceId
+        let updatedUser = AppUser(
+            id: user?.id ?? UUID(),
+            role: user?.role,
+            nickname: nickname,
+            profileImageURL: profileImageURL,
+            defaultRegionID: user?.defaultRegionID,
+            defaultRegionLabel: user?.defaultRegionLabel,
+            defaultServiceRegionID: user?.defaultServiceRegionID,
+            createdAt: user?.createdAt,
+            updatedAt: Date()
+        )
+        self.session = session
+        self.user = updatedUser
+        return (updatedUser, session)
+    }
+
+    func issueNailGenerationUploadURL(
+        traceId: String,
+        session: AppSession,
+        kind: NailGenUploadKind,
+        ext: String,
+        contentType: String,
+        bytes: Int,
+        jobId: UUID?
+    ) async throws -> (response: NailGenUploadURLResponse, session: AppSession) {
+        _ = traceId
+        _ = kind
+        _ = ext
+        _ = contentType
+        _ = bytes
+        let resolvedJobId = jobId ?? UUID()
+        return (
+            NailGenUploadURLResponse(
+                bucket: "preview",
+                jobId: resolvedJobId,
+                objectPath: "preview/\(resolvedJobId.uuidString).jpg",
+                signedUploadURL: "https://example.com/upload",
+                publicObjectURL: "https://example.com/generated-\(resolvedJobId.uuidString).jpg",
+                expiresInSec: 600
+            ),
+            session
+        )
+    }
+
+    func uploadImageToSignedURL(
+        traceId: String,
+        signedUploadURL: String,
+        contentType: String,
+        imageData: Data
+    ) async throws {
+        _ = traceId
+        _ = signedUploadURL
+        _ = contentType
+        _ = imageData
+    }
+
+    func createNailGenerationJob(
+        traceId: String,
+        session: AppSession,
+        shape: NailGenShape,
+        extensionMode: NailGenExtensionMode,
+        handObjectPath: String,
+        referenceObjectPath: String
+    ) async throws -> (response: NailGenCreateJobResponse, session: AppSession) {
+        _ = traceId
+        _ = shape
+        _ = extensionMode
+        _ = handObjectPath
+        _ = referenceObjectPath
+        return (
+            NailGenCreateJobResponse(
+                jobId: UUID(),
+                status: .completed,
+                pollAfterMs: 0
+            ),
+            session
+        )
+    }
+
+    func refineNailGenerationJob(
+        traceId: String,
+        session: AppSession,
+        sourceJobId: UUID,
+        shape: NailGenShape,
+        extensionMode: NailGenExtensionMode
+    ) async throws -> (response: NailGenRefineJobResponse, session: AppSession) {
+        _ = traceId
+        _ = sourceJobId
+        _ = shape
+        _ = extensionMode
+        return (
+            NailGenRefineJobResponse(
+                jobId: UUID(),
+                status: .completed,
+                pollAfterMs: 0
+            ),
+            session
+        )
+    }
+
+    func getNailGenerationJobStatus(
+        traceId: String,
+        session: AppSession,
+        jobId: UUID
+    ) async throws -> (response: NailGenJobStatusResponse, session: AppSession) {
+        _ = traceId
+        let response = await MainActor.run {
+            NailGenJobStatusResponse(
+                status: .completed,
+                resultImageURL: "https://example.com/result-\(jobId.uuidString).jpg",
+                errorCode: nil,
+                errorMessage: nil,
+                parentJobId: nil,
+                refinementTurn: 0,
+                canRefine: true
+            )
+        }
+        return (
+            response,
+            session
+        )
+    }
+
+    func fetchCompletedNailGenerationList(
+        traceId: String,
+        session: AppSession,
+        limit: Int,
+        cursor: String?,
+        likedOnly: Bool
+    ) async throws -> (response: NailGenListResponse, session: AppSession) {
+        _ = traceId
+        _ = cursor
+        let items = nailGenerationItems
+            .filter { likedOnly ? $0.isLiked : true }
+        return (
+            NailGenListResponse(
+                items: Array(items.prefix(limit)),
+                nextCursor: nil
+            ),
+            session
+        )
+    }
+
+    func setNailGenerationLike(
+        traceId: String,
+        session: AppSession,
+        jobId: UUID,
+        isLiked: Bool
+    ) async throws -> (response: NailGenLikeResponse, session: AppSession) {
+        _ = traceId
+        if let index = nailGenerationItems.firstIndex(where: { $0.jobId == jobId }) {
+            let current = nailGenerationItems[index]
+            nailGenerationItems[index] = await MainActor.run {
+                NailGenListItemResponse(
+                    jobId: current.jobId,
+                    resultImageURL: current.resultImageURL,
+                    thumbnailImageURL: current.thumbnailImageURL,
+                    shape: current.shape,
+                    extensionMode: current.extensionMode,
+                    createdAt: current.createdAt,
+                    parentJobId: current.parentJobId,
+                    refinementTurn: current.refinementTurn,
+                    isLiked: isLiked
+                )
+            }
+        }
+
+        return (
+            NailGenLikeResponse(
+                ok: true,
+                jobId: jobId,
+                isLiked: isLiked
+            ),
+            session
+        )
+    }
+
+    func deleteNailGeneration(
+        traceId: String,
+        session: AppSession,
+        jobId: UUID
+    ) async throws -> (response: NailGenDeleteResponse, session: AppSession) {
+        _ = traceId
+        nailGenerationItems.removeAll { $0.jobId == jobId || $0.parentJobId == jobId }
+        return (
+            NailGenDeleteResponse(
+                ok: true,
+                deletedJobIDs: [jobId]
+            ),
+            session
+        )
+    }
+
+    func deleteMyAccount(
+        traceId: String,
+        session: AppSession,
+        reason: String?
+    ) async throws {
+        _ = traceId
+        _ = session
+        _ = reason
+        self.session = nil
+        self.user = nil
+    }
+
+    func signOut(traceId: String) async {
+        _ = traceId
+        session = nil
+        user = nil
+    }
+
+    func clearLocalSession() async {
+        session = nil
+        user = nil
+    }
+
+    private func previewAuthResult(traceId: String) async throws -> AuthResult {
+        _ = traceId
+        guard let session, let user else {
+            throw EdgeAPIError(statusCode: 401, message: "Preview session unavailable", errorId: "preview-auth")
+        }
+        return AuthResult(
+            session: session,
+            user: user,
+            needsOnboarding: onboardingPrefill != nil,
+            onboardingPrefill: onboardingPrefill
+        )
+    }
+}
+#endif

--- a/NailClient/NailClient/App/RootView.swift
+++ b/NailClient/NailClient/App/RootView.swift
@@ -45,5 +45,10 @@ struct RootView: View {
 
 #Preview {
     RootView()
-        .environmentObject(AppViewModel())
+        .environmentObject(
+            AppViewModel.preview(
+                route: .home,
+                currentUser: .preview(nickname: "프리뷰 사용자")
+            )
+        )
 }

--- a/NailClient/NailClient/Domain/Models/AppUser.swift
+++ b/NailClient/NailClient/Domain/Models/AppUser.swift
@@ -29,7 +29,6 @@ struct AppUser: Codable, Sendable {
     }
 }
 
-#if DEBUG
 extension AppUser {
     nonisolated static func preview(
         id: UUID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
@@ -50,4 +49,3 @@ extension AppUser {
         )
     }
 }
-#endif

--- a/NailClient/NailClient/Domain/Models/AppUser.swift
+++ b/NailClient/NailClient/Domain/Models/AppUser.swift
@@ -28,3 +28,26 @@ struct AppUser: Codable, Sendable {
         case updatedAt = "updated_at"
     }
 }
+
+#if DEBUG
+extension AppUser {
+    nonisolated static func preview(
+        id: UUID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
+        role: String? = nil,
+        nickname: String? = "프리뷰 사용자",
+        profileImageURL: String? = nil
+    ) -> AppUser {
+        AppUser(
+            id: id,
+            role: role,
+            nickname: nickname,
+            profileImageURL: profileImageURL,
+            defaultRegionID: nil,
+            defaultRegionLabel: nil,
+            defaultServiceRegionID: nil,
+            createdAt: nil,
+            updatedAt: nil
+        )
+    }
+}
+#endif

--- a/NailClient/NailClient/Features/AIGeneration/ViewModels/AINailGenerationViewModel.swift
+++ b/NailClient/NailClient/Features/AIGeneration/ViewModels/AINailGenerationViewModel.swift
@@ -559,6 +559,24 @@ final class AINailGenerationViewModel: ObservableObject {
         }
     }
 
+    func makeAutoOpenedDetailItem(
+        createdAt: Date = Date()
+    ) -> FittedAIImagesViewModel.FittedAIImageItem? {
+        guard let currentJobId, let resultImageURL else { return nil }
+
+        return FittedAIImagesViewModel.FittedAIImageItem(
+            jobId: currentJobId,
+            thumbnailURL: nil,
+            fullImageURL: resultImageURL,
+            shape: selectedShape.apiValue,
+            extensionMode: selectedExtensionOption.apiValue,
+            createdAt: createdAt,
+            parentJobId: parentJobId,
+            refinementTurn: refinementTurn,
+            isLiked: false
+        )
+    }
+
     func setSelectedImagesForTesting(handData: Data?, referenceData: Data?) {
         handImageData = handData
         referenceImageData = referenceData

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -1200,7 +1200,13 @@ private struct AlmondNailPreviewShape: Shape {
 #Preview("기본") {
     NavigationStack {
         AINailGenerationView()
-            .environmentObject(AppViewModel())
+            .environmentObject(
+                AppViewModel.preview(
+                    route: .home,
+                    currentUser: .preview(nickname: "AI 프리뷰"),
+                    selectedMainTab: .ai
+                )
+            )
     }
 }
 
@@ -1213,7 +1219,13 @@ private struct AlmondNailPreviewShape: Shape {
                 statusMessage: "이미지 생성 중..."
             )
         )
-        .environmentObject(AppViewModel())
+        .environmentObject(
+            AppViewModel.preview(
+                route: .home,
+                currentUser: .preview(nickname: "AI 프리뷰"),
+                selectedMainTab: .ai
+            )
+        )
     }
 }
 #endif

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -33,6 +33,7 @@ struct AINailGenerationView: View {
     @State private var designSelectionToastTask: Task<Void, Never>?
     @State private var lastAppliedDesignPayloadID: UUID?
     @State private var lastAutoOpenedJobId: UUID?
+    @State private var directDetailOpenSuppressedJobId: UUID?
     @State private var isResolvingDetailItem: Bool = false
     @State private var detailResolveAlert: DetailResolveAlert?
     @State private var isConsentSheetPresented: Bool = false
@@ -905,10 +906,13 @@ struct AINailGenerationView: View {
     private func autoOpenDetailIfNeeded() {
         guard appViewModel.selectedMainTab == .ai else { return }
         guard !viewModel.isSubmitting else { return }
-        guard viewModel.resultImageURL != nil else { return }
         guard let jobId = viewModel.currentJobId else { return }
         guard lastAutoOpenedJobId != jobId else { return }
-        resolveAndOpenDetail(jobId: jobId)
+        guard directDetailOpenSuppressedJobId != jobId else { return }
+        guard let detailItem = viewModel.makeAutoOpenedDetailItem() else { return }
+
+        selectedDetailItem = detailItem
+        lastAutoOpenedJobId = jobId
     }
 
     private func resolveAndOpenDetail(jobId: UUID) {
@@ -997,6 +1001,7 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == response.jobId {
                 selectedDetailItem?.isLiked = response.isLiked
             }
+            refreshResultListCaches(includeLiked: true)
             return true
         } catch {
             return false
@@ -1009,9 +1014,17 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == jobId {
                 selectedDetailItem = nil
             }
+            refreshResultListCaches(includeLiked: true)
             return true
         } catch {
             return false
+        }
+    }
+
+    private func refreshResultListCaches(includeLiked: Bool) {
+        appViewModel.refreshNailGenerationFirstPageCache(likedOnly: false)
+        if includeLiked {
+            appViewModel.refreshNailGenerationFirstPageCache(likedOnly: true)
         }
     }
 
@@ -1123,6 +1136,7 @@ struct AINailGenerationView: View {
             return
         }
 
+        directDetailOpenSuppressedJobId = jobId
         let outcome = await viewModel.openResultFromPush(jobId: jobId)
         switch outcome {
         case .opened:

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -208,7 +208,7 @@ struct AINailGenerationView: View {
                 dismissButton: .default(Text("확인"))
             )
         }
-        .sheet(item: $handCropSource, onDismiss: {
+        .fullScreenCover(item: $handCropSource, onDismiss: {
             viewModel.selectedHandPhotoItem = nil
             handCropErrorMessage = nil
         }) { source in
@@ -237,10 +237,9 @@ struct AINailGenerationView: View {
                     }
                 }
             )
-            .presentationDetents([.large])
-            .presentationDragIndicator(.visible)
+            .ignoresSafeArea()
         }
-        .sheet(item: $referenceCropSource, onDismiss: {
+        .fullScreenCover(item: $referenceCropSource, onDismiss: {
             viewModel.selectedReferencePhotoItem = nil
             referenceCropErrorMessage = nil
         }) { source in
@@ -270,8 +269,7 @@ struct AINailGenerationView: View {
                     }
                 }
             )
-            .presentationDetents([.large])
-            .presentationDragIndicator(.visible)
+            .ignoresSafeArea()
         }
     }
 
@@ -673,47 +671,27 @@ struct AINailGenerationView: View {
         GeometryReader { proxy in
             let availableHeight = proxy.size.height - 56
             let compactLayout = availableHeight < 640 || dynamicTypeSize.isAccessibilitySize
-            let horizontalInset: CGFloat = compactLayout ? 30 : 28
-            let modalWidth: CGFloat = compactLayout
-                ? min(304, max(248, proxy.size.width - 60))
-                : min(320, max(260, proxy.size.width - 56))
-            let contentSpacing: CGFloat = compactLayout ? 10 : 14
-            let modalPadding: CGFloat = compactLayout ? 12 : 16
+            let contentWidth = min(320, max(248, proxy.size.width - 48))
+            let contentSpacing: CGFloat = compactLayout ? 22 : 28
 
             ZStack {
-                Rectangle()
-                    .fill(.ultraThinMaterial)
-                    .ignoresSafeArea()
-
-                Color.black.opacity(0.22)
+                Color.black.opacity(0.94)
                     .ignoresSafeArea()
 
                 VStack(spacing: contentSpacing) {
                     spinnerLoadingSection(compactLayout: compactLayout)
-
                     generationOverlayActionButtons
                 }
-                .padding(modalPadding)
-                .frame(width: modalWidth)
-                .fixedSize(horizontal: false, vertical: true)
-                .background(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(AIGenerationDesignTokens.generationModalBackground)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(AIGenerationDesignTokens.border, lineWidth: 1)
-                        )
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                .shadow(color: .black.opacity(0.20), radius: 12, x: 0, y: 6)
-                .padding(.horizontal, horizontalInset)
+                .frame(width: contentWidth)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.horizontal, 24)
                 .padding(.vertical, 28)
             }
         }
     }
 
     private func spinnerLoadingSection(compactLayout: Bool) -> some View {
-        VStack(spacing: compactLayout ? 8 : 10) {
+        VStack(spacing: compactLayout ? 10 : 12) {
             Text("오늘 네일 AI가\n생성중이에요")
                 .font(
                     .system(
@@ -721,7 +699,7 @@ struct AINailGenerationView: View {
                         weight: .semibold
                     )
                 )
-                .foregroundStyle(AIGenerationDesignTokens.primaryText)
+                .foregroundStyle(.white)
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
                 .minimumScaleFactor(0.9)
@@ -729,13 +707,13 @@ struct AINailGenerationView: View {
 
             ProgressView()
                 .progressViewStyle(.circular)
-                .tint(AIGenerationDesignTokens.accent)
+                .tint(.white)
                 .controlSize(compactLayout ? .regular : .large)
                 .scaleEffect(compactLayout ? 0.95 : 1.15)
 
             Text(generationOverlayStatusMessage)
                 .font(.system(AIGenerationDesignTokens.metaStyle, weight: .medium))
-                .foregroundStyle(AIGenerationDesignTokens.secondaryText)
+                .foregroundStyle(.white.opacity(0.82))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
                 .minimumScaleFactor(0.9)
@@ -743,7 +721,7 @@ struct AINailGenerationView: View {
 
             Text(generationOverlaySupportMessage)
                 .font(.system(AIGenerationDesignTokens.metaStyle, weight: .regular))
-                .foregroundStyle(AIGenerationDesignTokens.secondaryText)
+                .foregroundStyle(.white.opacity(0.68))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
                 .minimumScaleFactor(0.9)

--- a/NailClient/NailClient/Features/AIGeneration/Views/Components/DesignImageCropperView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/Components/DesignImageCropperView.swift
@@ -22,6 +22,8 @@ struct DesignImageCropperView: UIViewControllerRepresentable {
         controller.title = title
         controller.doneButtonTitle = "적용"
         controller.cancelButtonTitle = "취소"
+        controller.modalPresentationStyle = .fullScreen
+        controller.modalPresentationCapturesStatusBarAppearance = true
 
         // Basic crop flow only: keep drag/zoom + rectangular crop.
         controller.rotateButtonsHidden = true

--- a/NailClient/NailClient/Features/Home/Views/MainTabContainerView.swift
+++ b/NailClient/NailClient/Features/Home/Views/MainTabContainerView.swift
@@ -54,7 +54,13 @@ struct MainTabContainerView: View {
 struct MainTabContainerView_Previews: PreviewProvider {
     static var previews: some View {
         MainTabContainerView()
-            .environmentObject(AppViewModel())
+            .environmentObject(
+                AppViewModel.preview(
+                    route: .home,
+                    currentUser: .preview(nickname: "프리뷰 사용자"),
+                    selectedMainTab: .home
+                )
+            )
             .environment(\.dynamicTypeSize, .large)
             .preferredColorScheme(.light)
             .previewDevice("iPhone 17")

--- a/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
+++ b/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
@@ -128,5 +128,5 @@ struct LoginEntryView: View {
 
 #Preview {
     LoginEntryView()
-        .environmentObject(AppViewModel())
+        .environmentObject(AppViewModel.preview(route: .login, currentUser: nil, session: nil))
 }

--- a/NailClient/NailClient/Features/Onboarding/ViewModels/OnboardingProfileViewModel.swift
+++ b/NailClient/NailClient/Features/Onboarding/ViewModels/OnboardingProfileViewModel.swift
@@ -10,6 +10,14 @@ import SwiftUI
 import UIKit
 
 @MainActor
+protocol OnboardingProfileServicing: AnyObject {
+    func uploadProfileImage(imageData: Data) async throws -> String
+    func completeOnboarding(nickname: String, profileImageURL: String?) async
+}
+
+extension AppViewModel: OnboardingProfileServicing {}
+
+@MainActor
 final class OnboardingProfileViewModel: ObservableObject {
     enum PreferredStyle: String, CaseIterable, Identifiable {
         case officeMinimal = "오피스/미니멀"
@@ -71,6 +79,8 @@ final class OnboardingProfileViewModel: ObservableObject {
     @Published var showPhotoLoadErrorAlert: Bool = false
     @Published var photoUploadNoticeMessage: String?
 
+    private weak var service: (any OnboardingProfileServicing)?
+
     init(prefill: OnboardingPrefill? = nil) {
         let normalizedNickname = prefill?.nickname?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let normalizedNickname, !normalizedNickname.isEmpty {
@@ -124,6 +134,10 @@ final class OnboardingProfileViewModel: ObservableObject {
         prefilledProfileImageURL?.absoluteString
     }
 
+    func bind(service: any OnboardingProfileServicing) {
+        self.service = service
+    }
+
     func toggleStyle(_ style: PreferredStyle) {
         if selectedStyles.contains(style) {
             selectedStyles.remove(style)
@@ -138,8 +152,9 @@ final class OnboardingProfileViewModel: ObservableObject {
         selectedStyles.insert(style)
     }
 
-    func submit(appViewModel: AppViewModel) async {
+    func submit() async {
         guard isSubmitEnabled else { return }
+        guard let service else { return }
 
         let trimmed = trimmedNickname
         photoUploadNoticeMessage = nil
@@ -147,8 +162,8 @@ final class OnboardingProfileViewModel: ObservableObject {
         isSubmitting = true
         defer { isSubmitting = false }
 
-        let profileImageURL = await resolveProfileImageURLForSubmission(appViewModel: appViewModel)
-        await appViewModel.completeOnboarding(
+        let profileImageURL = await resolveProfileImageURLForSubmission()
+        await service.completeOnboarding(
             nickname: trimmed,
             profileImageURL: profileImageURL
         )
@@ -173,7 +188,11 @@ final class OnboardingProfileViewModel: ObservableObject {
         }
     }
 
-    private func resolveProfileImageURLForSubmission(appViewModel: AppViewModel) async -> String? {
+    private func resolveProfileImageURLForSubmission() async -> String? {
+        guard let service else {
+            return fallbackProfileImageURLForSubmission
+        }
+
         guard let profileUIImage else {
             return fallbackProfileImageURLForSubmission
         }
@@ -185,7 +204,7 @@ final class OnboardingProfileViewModel: ObservableObject {
         }
 
         do {
-            return try await appViewModel.uploadProfileImage(imageData: imageData)
+            return try await service.uploadProfileImage(imageData: imageData)
         } catch {
             photoUploadNoticeMessage = "프로필 사진 업로드에 실패했어요. 나중에 마이페이지 > 프로필 수정에서 다시 설정할 수 있어요."
             return fallbackProfileImageURLForSubmission

--- a/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileBasicsStepView.swift
+++ b/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileBasicsStepView.swift
@@ -10,10 +10,10 @@ import PhotosUI
 import UIKit
 
 struct OnboardingProfileBasicsStepView: View {
-    @EnvironmentObject private var appViewModel: AppViewModel
     @Environment(\.colorScheme) private var colorScheme
 
     @ObservedObject var viewModel: OnboardingProfileViewModel
+    let onSignOut: () -> Void
     let onNext: () -> Void
 
     @FocusState private var focusedField: Field?
@@ -56,7 +56,7 @@ struct OnboardingProfileBasicsStepView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
-                    Task { await appViewModel.signOut() }
+                    onSignOut()
                 } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 17, weight: .semibold))
@@ -253,7 +253,10 @@ struct OnboardingProfileBasicsStepView: View {
 
 #Preview {
     NavigationStack {
-        OnboardingProfileBasicsStepView(viewModel: OnboardingProfileViewModel(), onNext: {})
-            .environmentObject(AppViewModel())
+        OnboardingProfileBasicsStepView(
+            viewModel: OnboardingProfileViewModel(),
+            onSignOut: {},
+            onNext: {}
+        )
     }
 }

--- a/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileStyleStepView.swift
+++ b/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileStyleStepView.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 struct OnboardingProfileStyleStepView: View {
-    @EnvironmentObject private var appViewModel: AppViewModel
     @Environment(\.colorScheme) private var colorScheme
 
     @ObservedObject var viewModel: OnboardingProfileViewModel
+    let styleImageURLs: [String: URL]
+    let onRefreshStyleAssets: () async -> Void
 
     private var primary: Color { LoginDesignTokens.primaryHTML }
     private var brandPrimary: Color { LoginDesignTokens.brandPrimary }
@@ -44,7 +45,7 @@ struct OnboardingProfileStyleStepView: View {
         .navigationBarBackButtonHidden(false)
         .onAppear {
             Task {
-                await appViewModel.refreshOnboardingStyleAssets()
+                await onRefreshStyleAssets()
             }
         }
     }
@@ -131,7 +132,7 @@ struct OnboardingProfileStyleStepView: View {
 
     @ViewBuilder
     private func styleBackground(for style: OnboardingProfileViewModel.PreferredStyle) -> some View {
-        if let remoteURL = appViewModel.onboardingStyleImageURLs[style.styleKey] {
+        if let remoteURL = styleImageURLs[style.styleKey] {
             NailRemoteImage(
                 url: remoteURL,
                 targetSize: CGSize(width: 220, height: 220),
@@ -204,7 +205,7 @@ struct OnboardingProfileStyleStepView: View {
     private var ctaSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Button {
-                Task { await viewModel.submit(appViewModel: appViewModel) }
+                Task { await viewModel.submit() }
             } label: {
                 HStack(spacing: 10) {
                     if viewModel.isSubmitting {
@@ -233,7 +234,10 @@ struct OnboardingProfileStyleStepView: View {
 
 #Preview {
     NavigationStack {
-        OnboardingProfileStyleStepView(viewModel: OnboardingProfileViewModel())
-            .environmentObject(AppViewModel())
+        OnboardingProfileStyleStepView(
+            viewModel: OnboardingProfileViewModel(),
+            styleImageURLs: [:],
+            onRefreshStyleAssets: {}
+        )
     }
 }

--- a/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileView.swift
+++ b/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileView.swift
@@ -22,12 +22,26 @@ struct OnboardingProfileView: View {
 
     var body: some View {
         NavigationStack {
-            OnboardingProfileBasicsStepView(viewModel: viewModel) {
+            OnboardingProfileBasicsStepView(
+                viewModel: viewModel,
+                onSignOut: {
+                    Task { await appViewModel.signOut() }
+                }
+            ) {
                 showStyleStep = true
             }
             .navigationDestination(isPresented: $showStyleStep) {
-                OnboardingProfileStyleStepView(viewModel: viewModel)
+                OnboardingProfileStyleStepView(
+                    viewModel: viewModel,
+                    styleImageURLs: appViewModel.onboardingStyleImageURLs,
+                    onRefreshStyleAssets: {
+                        await appViewModel.refreshOnboardingStyleAssets()
+                    }
+                )
             }
+        }
+        .onAppear {
+            viewModel.bind(service: appViewModel)
         }
         .alert(
             "오류",
@@ -56,6 +70,17 @@ struct OnboardingProfileView: View {
 }
 
 #Preview {
-    OnboardingProfileView()
-        .environmentObject(AppViewModel())
+    let prefill = OnboardingPrefill(
+        nickname: "네일러",
+        profileImageURL: "https://example.com/profile.png"
+    )
+
+    return OnboardingProfileView(prefill: prefill)
+        .environmentObject(
+            AppViewModel.preview(
+                route: .onboarding,
+                currentUser: .preview(nickname: "네일러", profileImageURL: "https://example.com/profile.png"),
+                onboardingPrefill: prefill
+            )
+        )
 }

--- a/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileView.swift
+++ b/NailClient/NailClient/Features/Onboarding/Views/OnboardingProfileView.swift
@@ -75,7 +75,7 @@ struct OnboardingProfileView: View {
         profileImageURL: "https://example.com/profile.png"
     )
 
-    return OnboardingProfileView(prefill: prefill)
+    OnboardingProfileView(prefill: prefill)
         .environmentObject(
             AppViewModel.preview(
                 route: .onboarding,

--- a/NailClient/NailClient/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -7,6 +7,17 @@ import Foundation
 import Combine
 
 @MainActor
+protocol ProfileServicing: AnyObject {
+    var errorMessage: String? { get }
+
+    func updateMyProfile(nickname: String) async -> Bool
+    func uploadProfileImage(imageData: Data) async throws -> String
+    func updateMyProfileImage(profileImageURL: String?) async -> Bool
+}
+
+extension AppViewModel: ProfileServicing {}
+
+@MainActor
 final class ProfileViewModel: ObservableObject {
     private static let profilePhotoUpdatedToastDefaultMessage = "프로필 사진이 변경되었어요."
 
@@ -33,11 +44,14 @@ final class ProfileViewModel: ObservableObject {
     @Published var nickname: String = ""
     @Published var isEditSheetPresented: Bool = false
     @Published private(set) var isSaving: Bool = false
+    @Published private(set) var isUploadingProfilePhoto: Bool = false
     @Published private(set) var saveErrorMessage: String?
     @Published private(set) var profilePhotoToastMessage: String?
+    @Published var profilePhotoErrorMessage: String?
     @Published var comingSoonItem: ComingSoonItem?
 
     private let profilePhotoToastDuration: Duration
+    private weak var service: (any ProfileServicing)?
     private var profilePhotoToastDismissTask: Task<Void, Never>?
 
     private var originalNickname: String = ""
@@ -74,6 +88,10 @@ final class ProfileViewModel: ObservableObject {
         !isSaving
             && nicknameValidationMessage == nil
             && hasChanges
+    }
+
+    func bind(service: any ProfileServicing) {
+        self.service = service
     }
 
     func makeHeaderDisplay(from user: AppUser?) -> ProfileHeaderDisplay {
@@ -129,14 +147,42 @@ final class ProfileViewModel: ObservableObject {
         comingSoonItem = item
     }
 
-    func save(appViewModel: AppViewModel) async {
+    func uploadProfilePhoto(imageData: Data) async {
+        guard !isUploadingProfilePhoto else { return }
+        guard let service else {
+            profilePhotoErrorMessage = "프로필 사진 변경을 준비하지 못했어요."
+            return
+        }
+
+        isUploadingProfilePhoto = true
+        profilePhotoErrorMessage = nil
+        defer { isUploadingProfilePhoto = false }
+
+        do {
+            let uploadedURL = try await service.uploadProfileImage(imageData: imageData)
+            let updated = await service.updateMyProfileImage(profileImageURL: uploadedURL)
+            if updated {
+                showProfilePhotoUpdatedToast()
+            } else {
+                profilePhotoErrorMessage = service.errorMessage ?? "프로필 사진 변경에 실패했어요."
+            }
+        } catch {
+            profilePhotoErrorMessage = Self.profilePhotoErrorMessage(for: error)
+        }
+    }
+
+    func save() async {
         guard isSaveEnabled else { return }
+        guard let service else {
+            saveErrorMessage = "프로필 저장을 준비하지 못했어요."
+            return
+        }
 
         isSaving = true
         saveErrorMessage = nil
         defer { isSaving = false }
 
-        let success = await appViewModel.updateMyProfile(
+        let success = await service.updateMyProfile(
             nickname: trimmedNickname
         )
 
@@ -146,11 +192,27 @@ final class ProfileViewModel: ObservableObject {
             return
         }
 
-        saveErrorMessage = appViewModel.errorMessage ?? "프로필 수정에 실패했어요."
+        saveErrorMessage = service.errorMessage ?? "프로필 수정에 실패했어요."
     }
 
     private func clearProfilePhotoToast() {
         profilePhotoToastMessage = nil
         profilePhotoToastDismissTask = nil
+    }
+
+    private static func profilePhotoErrorMessage(for error: Error) -> String {
+        if let edgeError = error as? EdgeAPIError {
+            if let errorId = edgeError.errorId, !errorId.isEmpty {
+                return "프로필 사진 업로드 실패 (\(errorId)): \(edgeError.message)"
+            }
+            return "프로필 사진 업로드 실패: \(edgeError.message)"
+        }
+
+        let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !description.isEmpty {
+            return "프로필 사진 업로드 실패: \(description)"
+        }
+
+        return "프로필 사진 업로드에 실패했어요. 잠시 후 다시 시도해 주세요."
     }
 }

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -21,17 +21,6 @@ struct FittedAIImageDetailSheet: View {
 
         var id: Int { rawValue }
 
-        var badgeTitle: String {
-            switch self {
-            case .generated:
-                return "1 결과"
-            case .hand:
-                return "2 원본 손"
-            case .reference:
-                return "3 디자인"
-            }
-        }
-
         var shortTitle: String {
             switch self {
             case .generated:
@@ -61,6 +50,9 @@ struct FittedAIImageDetailSheet: View {
     @State private var isDeleting: Bool = false
     @State private var isDownloading: Bool = false
     @State private var showDeleteConfirmAlert: Bool = false
+    @State private var contentHeight: CGFloat = 0
+    @State private var viewportHeight: CGFloat = 0
+    @State private var isScrollEnabled: Bool = false
 
     init(
         item: FittedAIImagesViewModel.FittedAIImageItem,
@@ -95,7 +87,21 @@ struct FittedAIImageDetailSheet: View {
                 .padding(.horizontal, 16)
                 .padding(.top, 16)
                 .padding(.bottom, 22)
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear
+                            .preference(key: DetailSheetContentHeightPreferenceKey.self, value: proxy.size.height)
+                    }
+                )
             }
+            .scrollDisabled(!isScrollEnabled)
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: DetailSheetViewportHeightPreferenceKey.self, value: proxy.size.height)
+                }
+            )
             .background(ProfileDesignTokens.pageBackground.ignoresSafeArea())
             .navigationTitle("오늘 네일 AI 피팅 상세")
             .navigationBarTitleDisplayMode(.inline)
@@ -108,6 +114,14 @@ struct FittedAIImageDetailSheet: View {
             .onChange(of: selectedGalleryIndex) { _, nextIndex in
                 prefetchAdjacentGalleryImages(around: nextIndex)
             }
+            .onPreferenceChange(DetailSheetContentHeightPreferenceKey.self) { nextHeight in
+                contentHeight = nextHeight
+                updateScrollState()
+            }
+            .onPreferenceChange(DetailSheetViewportHeightPreferenceKey.self) { nextHeight in
+                viewportHeight = nextHeight
+                updateScrollState()
+            }
             .interactiveDismissDisabled(isDeleting)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -117,33 +131,19 @@ struct FittedAIImageDetailSheet: View {
                     .disabled(isDeleting)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Menu {
-                        Button {
-                            Task { await downloadGeneratedImage() }
-                        } label: {
-                            Label(
-                                isDownloading ? "저장 중..." : "사진에 저장",
-                                systemImage: "arrow.down.to.line"
-                            )
-                        }
-                        .accessibilityLabel("결과 이미지 저장")
-                        .disabled(isDownloading || isDeleting)
-
-                        Button(role: .destructive) {
-                            showDeleteConfirmAlert = true
-                        } label: {
-                            Label(
-                                isDeleting ? "삭제 중..." : "삭제하기",
-                                systemImage: "trash"
-                            )
-                        }
-                        .accessibilityLabel("이미지 삭제")
-                        .disabled(isDeleting)
+                    Button {
+                        Task { await toggleLike() }
                     } label: {
-                        Image(systemName: "ellipsis.circle")
+                        Image(systemName: isLiked ? "heart.fill" : "heart")
+                            .appTypography(size: 18, weight: .bold)
+                            .foregroundStyle(isLiked ? ProfileDesignTokens.destructive : ProfileDesignTokens.primaryText)
                     }
-                    .disabled(isDeleting)
-                    .accessibilityLabel("상세 액션 메뉴")
+                    .buttonStyle(.plain)
+                    .disabled(isLikeUpdating || isDeleting)
+                    .transaction { transaction in
+                        transaction.animation = nil
+                    }
+                    .accessibilityLabel(isLiked ? "좋아요 해제" : "좋아요")
                 }
             }
             .alert(item: $activeAlert) { alert in
@@ -166,10 +166,10 @@ struct FittedAIImageDetailSheet: View {
 
     @ViewBuilder
     private var gallerySection: some View {
-        if isGalleryLoading && !hasLoadedDetailImages {
-            gallerySkeleton
-        } else {
-            VStack(spacing: 10) {
+        VStack(spacing: 12) {
+            if isGalleryLoading && !hasLoadedDetailImages {
+                gallerySkeleton
+            } else {
                 TabView(selection: $selectedGalleryIndex) {
                     ForEach(GallerySlot.allCases) { slot in
                         galleryPage(for: slot)
@@ -177,56 +177,43 @@ struct FittedAIImageDetailSheet: View {
                     }
                 }
                 .frame(maxWidth: .infinity)
-                .aspectRatio(4.0 / 5.0, contentMode: .fit)
+                .aspectRatio(1, contentMode: .fit)
                 .frame(maxHeight: 560)
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
                         .stroke(ProfileDesignTokens.cardBorder, lineWidth: 1)
                 )
-                .overlay(alignment: .topTrailing) {
-                    VStack(alignment: .trailing, spacing: 8) {
-                        settingsChipRow
-
-                        Button {
-                            Task { await toggleLike() }
-                        } label: {
-                            Image(systemName: isLiked ? "heart.fill" : "heart")
-                                .appTypography(size: 18, weight: .bold)
-                                .foregroundStyle(isLiked ? ProfileDesignTokens.destructive : ProfileDesignTokens.secondaryText)
-                                .frame(width: 40, height: 40)
-                                .background(
-                                    Circle()
-                                        .fill(ProfileDesignTokens.pageBackground.opacity(0.92))
-                                )
-                                .overlay(
-                                    Circle()
-                                        .stroke(ProfileDesignTokens.cardBorder, lineWidth: 1)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isLikeUpdating || isDeleting)
-                        .opacity((isLikeUpdating || isDeleting) ? 0.85 : 1)
-                    }
-                    .padding(10)
+                .overlay(alignment: .topLeading) {
+                    galleryHeader
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
 
-                HStack(spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
                     ForEach(GallerySlot.allCases) { slot in
                         galleryThumbnail(for: slot)
                     }
                 }
             }
+
+            galleryActionRow
         }
     }
 
     private var gallerySkeleton: some View {
-        VStack(spacing: 10) {
-            SkeletonBlock(height: 420, cornerRadius: 14)
-            HStack(spacing: 8) {
+        VStack(spacing: 12) {
+            galleryMainSkeleton
+
+            HStack(alignment: .top, spacing: 8) {
                 ForEach(0..<3, id: \.self) { _ in
-                    SkeletonBlock(height: 72, cornerRadius: 10)
+                    VStack(spacing: 6) {
+                        galleryThumbnailSkeleton
+
+                        SkeletonBlock(height: 12, cornerRadius: 6)
+                            .frame(maxWidth: .infinity)
+                            .padding(.horizontal, 12)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .top)
                 }
             }
         }
@@ -236,7 +223,7 @@ struct FittedAIImageDetailSheet: View {
     private func galleryPage(for slot: GallerySlot) -> some View {
         let imageURL = galleryURL(for: slot)
 
-        ZStack(alignment: .topLeading) {
+        ZStack {
             if let imageURL {
                 NailRemoteImage(
                     url: imageURL,
@@ -251,7 +238,7 @@ struct FittedAIImageDetailSheet: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .background(ProfileDesignTokens.cardBackground)
                     case .empty:
-                        SkeletonBlock(height: 420, cornerRadius: 14)
+                        galleryLoadingPlaceholder(cornerRadius: 14)
                     case .failure:
                         galleryPlaceholder(title: slot.shortTitle)
                     @unknown default:
@@ -262,20 +249,6 @@ struct FittedAIImageDetailSheet: View {
                 galleryPlaceholder(title: slot.shortTitle)
             }
 
-            Text(slot.badgeTitle)
-                .appTypography(size: 11, weight: .bold)
-                .foregroundStyle(ProfileDesignTokens.secondaryText)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(ProfileDesignTokens.pageBackground.opacity(0.92))
-                )
-                .overlay(
-                    Capsule(style: .continuous)
-                        .stroke(ProfileDesignTokens.cardBorder, lineWidth: 1)
-                )
-                .padding(10)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -309,8 +282,8 @@ struct FittedAIImageDetailSheet: View {
                         thumbnailPlaceholder
                     }
                 }
-                .frame(height: 72)
                 .frame(maxWidth: .infinity)
+                .aspectRatio(1, contentMode: .fit)
                 .background(ProfileDesignTokens.aiHistoryPromptBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .overlay(
@@ -330,9 +303,12 @@ struct FittedAIImageDetailSheet: View {
                             ? ProfileDesignTokens.accent
                             : ProfileDesignTokens.secondaryText
                     )
+                    .lineLimit(1)
             }
+            .frame(maxWidth: .infinity, alignment: .top)
         }
         .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .top)
     }
 
     private var thumbnailPlaceholder: some View {
@@ -340,6 +316,32 @@ struct FittedAIImageDetailSheet: View {
             .appTypography(size: 16, weight: .medium)
             .foregroundStyle(ProfileDesignTokens.sectionTitle)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var galleryMainSkeleton: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(FeedDesignTokens.skeletonBase)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            .shimmer()
+            .accessibilityHidden(true)
+    }
+
+    private var galleryThumbnailSkeleton: some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(FeedDesignTokens.skeletonBase)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            .shimmer()
+            .accessibilityHidden(true)
+    }
+
+    private func galleryLoadingPlaceholder(cornerRadius: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(FeedDesignTokens.skeletonBase)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .shimmer()
+            .accessibilityHidden(true)
     }
 
     private func galleryPlaceholder(title: String) -> some View {
@@ -392,35 +394,50 @@ struct FittedAIImageDetailSheet: View {
         return chips
     }
 
-    @ViewBuilder
-    private var settingsChipRow: some View {
-        if !settingsChipTexts.isEmpty {
-            HStack(spacing: 6) {
-                ForEach(Array(settingsChipTexts.enumerated()), id: \.offset) { _, text in
-                    settingsChip(text)
-                }
-            }
-        }
+    private var settingsMetadataText: String? {
+        guard !settingsChipTexts.isEmpty else { return nil }
+        return settingsChipTexts.joined(separator: " · ")
     }
 
-    private func settingsChip(_ text: String) -> some View {
-        Text(text)
-            .appTypography(size: 11, weight: .semibold)
-            .foregroundStyle(ProfileDesignTokens.secondaryText)
-            .lineLimit(1)
-            .minimumScaleFactor(0.85)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(ProfileDesignTokens.pageBackground.opacity(0.92))
-                    .overlay(
-                        Capsule(style: .continuous)
-                            .stroke(ProfileDesignTokens.cardBorder, lineWidth: 1)
-                    )
-            )
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("설정 칩, \(text)")
+    private var galleryHeader: some View {
+        HStack(alignment: .top, spacing: 0) {
+            if let settingsMetadataText {
+                Text(settingsMetadataText)
+                    .appTypography(size: 12, weight: .medium)
+                    .foregroundStyle(.white.opacity(0.90))
+                    .multilineTextAlignment(.leading)
+                    .shadow(color: .black.opacity(0.18), radius: 4, x: 0, y: 1)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("설정 정보, \(settingsMetadataText)")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 14)
+        .padding(.top, 14)
+        .allowsHitTesting(false)
+    }
+
+    private var galleryActionRow: some View {
+        VStack(spacing: 10) {
+            DetailSheetActionButton(
+                title: isDownloading ? "저장 중..." : "AI 네일 저장하기",
+                variant: .primary,
+                isDisabled: isDownloading || isDeleting
+            ) {
+                Task { await downloadGeneratedImage() }
+            }
+            .accessibilityLabel("AI 네일 저장하기")
+
+            DetailSheetActionButton(
+                title: isDeleting ? "삭제 중..." : "삭제하기",
+                variant: .destructive,
+                role: .destructive,
+                isDisabled: isDeleting
+            ) {
+                showDeleteConfirmAlert = true
+            }
+            .accessibilityLabel("이미지 삭제")
+        }
     }
 
     private func inlineGalleryError(message: String) -> some View {
@@ -474,6 +491,15 @@ struct FittedAIImageDetailSheet: View {
             hasLoadedDetailImages = true
             galleryErrorMessage = "입력 이미지를 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
         }
+    }
+
+    private func updateScrollState() {
+        guard viewportHeight > 0 else {
+            isScrollEnabled = false
+            return
+        }
+
+        isScrollEnabled = contentHeight > (viewportHeight + 1)
     }
 
     private func prefetchAdjacentGalleryImages(around index: Int) {
@@ -605,8 +631,124 @@ struct FittedAIImageDetailSheet: View {
     }
 }
 
+private struct DetailSheetActionButton: View {
+    enum Variant {
+        case primary
+        case destructive
+    }
+
+    let title: String
+    let variant: Variant
+    var role: ButtonRole? = nil
+    var isDisabled: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(role: role, action: action) {
+            Text(title)
+                .appTypography(size: 15, weight: .semibold)
+                .foregroundStyle(foregroundColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(backgroundShape)
+                .contentShape(RoundedRectangle(cornerRadius: AppRadiusTokens.md, style: .continuous))
+        }
+        .buttonStyle(PressScaleButtonStyle())
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.62 : 1)
+    }
+
+    private var foregroundColor: Color {
+        switch variant {
+        case .primary:
+            return .white
+        case .destructive:
+            return ProfileDesignTokens.destructive
+        }
+    }
+
+    @ViewBuilder
+    private var backgroundShape: some View {
+        let shape = RoundedRectangle(cornerRadius: AppRadiusTokens.md, style: .continuous)
+
+        switch variant {
+        case .primary:
+            shape
+                .fill(ProfileDesignTokens.accent)
+                .overlay(
+                    shape.stroke(ProfileDesignTokens.accent, lineWidth: 1)
+                )
+        case .destructive:
+            shape
+                .fill(ProfileDesignTokens.cardBackground)
+                .overlay(
+                    shape.stroke(ProfileDesignTokens.destructive.opacity(0.24), lineWidth: 1)
+                )
+        }
+    }
+}
+
 private enum DownloadError: Error {
     case invalidImageData
     case photoPermissionDenied
     case saveFailed
 }
+
+private struct DetailSheetContentHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct DetailSheetViewportHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+#if DEBUG
+private enum FittedAIImageDetailSheetPreviewData {
+    static let generatedURL = URL(string: "https://picsum.photos/seed/nail-generated/720/720")
+    static let handURL = URL(string: "https://picsum.photos/seed/nail-hand/720/720")
+    static let referenceURL = URL(string: "https://picsum.photos/seed/nail-reference/720/720")
+
+    static let item = FittedAIImagesViewModel.FittedAIImageItem(
+        jobId: UUID(uuidString: "11111111-2222-3333-4444-555555555555") ?? UUID(),
+        thumbnailURL: generatedURL,
+        fullImageURL: generatedURL,
+        shape: .almond,
+        extensionMode: .extend,
+        createdAt: Date(timeIntervalSince1970: 1_746_662_400),
+        parentJobId: nil,
+        refinementTurn: 0,
+        isLiked: true
+    )
+
+    static let detailImageSet = FittedAIImagesViewModel.DetailImageSet(
+        generatedURL: generatedURL,
+        handURL: handURL,
+        referenceURL: referenceURL
+    )
+}
+
+#Preview("AI 피팅 상세") {
+    FittedAIImageDetailSheet(
+        item: FittedAIImageDetailSheetPreviewData.item,
+        onLoadDetailImages: { _, _ in
+            FittedAIImageDetailSheetPreviewData.detailImageSet
+        },
+        onToggleLike: { nextLikeState in
+            nextLikeState
+        },
+        onDelete: {
+            false
+        }
+    )
+}
+#endif

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -313,6 +313,12 @@ struct FittedAIImagesView: View {
 #Preview {
     NavigationStack {
         FittedAIImagesView()
-            .environmentObject(AppViewModel())
+            .environmentObject(
+                AppViewModel.preview(
+                    route: .home,
+                    currentUser: .preview(nickname: "결과 프리뷰"),
+                    selectedMainTab: .results
+                )
+            )
     }
 }

--- a/NailClient/NailClient/Features/Profile/Views/ProfileEditSheetView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/ProfileEditSheetView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 import UIKit
 
 struct ProfileEditSheetView: View {
-    @EnvironmentObject private var appViewModel: AppViewModel
     @ObservedObject var viewModel: ProfileViewModel
 
     @FocusState private var focusedField: Field?
@@ -175,12 +174,11 @@ struct ProfileEditSheetView: View {
 
         focusedField = nil
         Task {
-            await viewModel.save(appViewModel: appViewModel)
+            await viewModel.save()
         }
     }
 }
 
 #Preview {
     ProfileEditSheetView(viewModel: ProfileViewModel())
-        .environmentObject(AppViewModel())
 }

--- a/NailClient/NailClient/Features/Profile/Views/ProfileView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/ProfileView.swift
@@ -14,8 +14,6 @@ struct ProfileView: View {
     @State private var isFittedAIImagesPresented: Bool = false
     @State private var isSettingsPresented: Bool = false
     @State private var selectedProfilePhotoItem: PhotosPickerItem?
-    @State private var isUploadingProfilePhoto: Bool = false
-    @State private var profilePhotoErrorMessage: String?
 
     private let activityItems: [ProfileMenuRowItem] = [
         .init(icon: "sparkles", title: "내가 피팅한 AI 이미지", tint: ProfileDesignTokens.accent, action: .fittedAIImages)
@@ -37,52 +35,28 @@ struct ProfileView: View {
     private func handleProfilePhotoSelection(_ item: PhotosPickerItem?) {
         guard let item else { return }
         Task {
-            await uploadSelectedProfilePhoto(item)
+            await uploadSelectedProfilePhotoData(item)
             selectedProfilePhotoItem = nil
         }
     }
 
-    private func uploadSelectedProfilePhoto(_ item: PhotosPickerItem) async {
-        guard !isUploadingProfilePhoto else { return }
-        isUploadingProfilePhoto = true
-        defer { isUploadingProfilePhoto = false }
-
+    private func uploadSelectedProfilePhotoData(_ item: PhotosPickerItem) async {
         do {
             guard let data = try await item.loadTransferable(type: Data.self) else {
                 throw EdgeAPIError(statusCode: -1, message: "이미지 데이터를 읽을 수 없습니다.", errorId: nil)
             }
-            let jpegData: Data
-            do {
-                jpegData = try ImageCompression.normalizedJPEGData(from: data)
-            } catch {
-                throw EdgeAPIError(statusCode: -1, message: "이미지 변환에 실패했습니다.", errorId: nil)
-            }
-
-            let uploadedURL = try await appViewModel.uploadProfileImage(imageData: jpegData)
-            let updated = await appViewModel.updateMyProfileImage(profileImageURL: uploadedURL)
-            if updated {
-                viewModel.showProfilePhotoUpdatedToast()
-            } else {
-                profilePhotoErrorMessage = appViewModel.errorMessage ?? "프로필 사진 변경에 실패했어요."
-            }
+            let jpegData = try ImageCompression.normalizedJPEGData(from: data)
+            await viewModel.uploadProfilePhoto(imageData: jpegData)
         } catch {
-            profilePhotoErrorMessage = errorMessage(for: error)
-        }
-    }
-
-    private func errorMessage(for error: Error) -> String {
-        if let edgeError = error as? EdgeAPIError {
-            if let errorId = edgeError.errorId, !errorId.isEmpty {
-                return "프로필 사진 업로드 실패 (\(errorId)): \(edgeError.message)"
+            let message: String
+            if let edgeError = error as? EdgeAPIError {
+                message = edgeError.message
+            } else {
+                let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+                message = description.isEmpty ? "프로필 사진 업로드에 실패했어요. 잠시 후 다시 시도해 주세요." : description
             }
-            return "프로필 사진 업로드 실패: \(edgeError.message)"
+            viewModel.profilePhotoErrorMessage = message
         }
-
-        let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !description.isEmpty {
-            return "프로필 사진 업로드 실패: \(description)"
-        }
-        return "프로필 사진 업로드에 실패했어요. 잠시 후 다시 시도해 주세요."
     }
 
     private func handleMenuAction(_ action: ProfileMenuRowAction) {
@@ -129,28 +103,15 @@ struct ProfileView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView(showsIndicators: false) {
-                VStack(spacing: ProfileDesignTokens.sectionSpacing) {
-                    ProfileHeroSectionView(
-                        display: headerDisplay,
-                        selectedPhotoItem: $selectedProfilePhotoItem,
-                        isUploadingPhoto: isUploadingProfilePhoto,
-                        onTapEditProfile: beginEdit
-                    )
-                    ProfileMenuSectionView(title: "내 활동", items: activityItems) { action in
-                        handleMenuAction(action)
-                    }
-                    ProfileMenuSectionView(title: "계정 및 설정", items: accountItems) { action in
-                        handleMenuAction(action)
-                    }
-                }
-                .padding(.horizontal, ProfileDesignTokens.horizontalPadding)
-                .padding(.top, 10)
-                .padding(.bottom, 20)
-            }
-            .background(ProfileDesignTokens.pageBackground.ignoresSafeArea())
-            .navigationTitle("마이페이지")
-            .navigationBarTitleDisplayMode(.inline)
+            ProfileScreen(
+                display: headerDisplay,
+                activityItems: activityItems,
+                accountItems: accountItems,
+                selectedPhotoItem: $selectedProfilePhotoItem,
+                isUploadingPhoto: viewModel.isUploadingProfilePhoto,
+                onTapEditProfile: beginEdit,
+                onMenuAction: handleMenuAction
+            )
             .navigationDestination(isPresented: $isSettingsPresented) {
                 SettingsView()
                     .environmentObject(appViewModel)
@@ -161,6 +122,7 @@ struct ProfileView: View {
             }
         }
         .onAppear {
+            viewModel.bind(service: appViewModel)
             viewModel.sync(from: appViewModel.currentUser)
         }
         .onReceive(appViewModel.$currentUser) { newUser in
@@ -171,7 +133,6 @@ struct ProfileView: View {
         }
         .sheet(isPresented: $viewModel.isEditSheetPresented) {
             ProfileEditSheetView(viewModel: viewModel)
-                .environmentObject(appViewModel)
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
@@ -193,19 +154,19 @@ struct ProfileView: View {
         .alert(
             "사진 변경 실패",
             isPresented: Binding(
-                get: { profilePhotoErrorMessage != nil },
+                get: { viewModel.profilePhotoErrorMessage != nil },
                 set: { isPresented in
                     if !isPresented {
-                        profilePhotoErrorMessage = nil
+                        viewModel.profilePhotoErrorMessage = nil
                     }
                 }
             )
         ) {
             Button("확인", role: .cancel) {
-                profilePhotoErrorMessage = nil
+                viewModel.profilePhotoErrorMessage = nil
             }
         } message: {
-            Text(profilePhotoErrorMessage ?? "프로필 사진 변경 중 오류가 발생했어요.")
+            Text(viewModel.profilePhotoErrorMessage ?? "프로필 사진 변경 중 오류가 발생했어요.")
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             profilePhotoToast
@@ -216,7 +177,51 @@ struct ProfileView: View {
     }
 }
 
+private struct ProfileScreen: View {
+    let display: ProfileViewModel.ProfileHeaderDisplay
+    let activityItems: [ProfileMenuRowItem]
+    let accountItems: [ProfileMenuRowItem]
+    @Binding var selectedPhotoItem: PhotosPickerItem?
+    let isUploadingPhoto: Bool
+    let onTapEditProfile: () -> Void
+    let onMenuAction: (ProfileMenuRowAction) -> Void
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: ProfileDesignTokens.sectionSpacing) {
+                ProfileHeroSectionView(
+                    display: display,
+                    selectedPhotoItem: $selectedPhotoItem,
+                    isUploadingPhoto: isUploadingPhoto,
+                    onTapEditProfile: onTapEditProfile
+                )
+                ProfileMenuSectionView(title: "내 활동", items: activityItems) { action in
+                    onMenuAction(action)
+                }
+                ProfileMenuSectionView(title: "계정 및 설정", items: accountItems) { action in
+                    onMenuAction(action)
+                }
+            }
+            .padding(.horizontal, ProfileDesignTokens.horizontalPadding)
+            .padding(.top, 10)
+            .padding(.bottom, 20)
+        }
+        .background(ProfileDesignTokens.pageBackground.ignoresSafeArea())
+        .navigationTitle("마이페이지")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
 #Preview {
     ProfileView()
-        .environmentObject(AppViewModel())
+        .environmentObject(
+            AppViewModel.preview(
+                route: .home,
+                currentUser: .preview(
+                    nickname: "오늘네일러",
+                    profileImageURL: "https://example.com/profile.png"
+                ),
+                selectedMainTab: .myPage
+            )
+        )
 }

--- a/NailClient/NailClient/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/NailClient/NailClient/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,93 @@
+//
+//  SettingsViewModel.swift
+//  NailClient
+//
+
+import Foundation
+import Combine
+
+@MainActor
+protocol SettingsServicing: AnyObject {
+    var errorMessage: String? { get }
+
+    func deleteMyAccount(reason: String?) async -> Bool
+}
+
+extension AppViewModel: SettingsServicing {}
+
+protocol AITransferConsentStoring {
+    var hasConsent: Bool { get }
+    func revokeConsent()
+}
+
+extension AITransferConsentStore: AITransferConsentStoring {}
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published var showDeleteConfirmAlert: Bool = false
+    @Published var showDeleteFinalAlert: Bool = false
+    @Published private(set) var isDeletingAccount: Bool = false
+    @Published var deleteErrorMessage: String?
+    @Published private(set) var hasAITransferConsent: Bool = false
+    @Published var showRevokeConsentConfirmAlert: Bool = false
+
+    private let consentStore: any AITransferConsentStoring
+    private weak var service: (any SettingsServicing)?
+
+    init(consentStore: (any AITransferConsentStoring)? = nil) {
+        let resolvedConsentStore = consentStore ?? AITransferConsentStore.shared
+        self.consentStore = resolvedConsentStore
+        self.hasAITransferConsent = resolvedConsentStore.hasConsent
+    }
+
+    var appVersionText: String {
+        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "-"
+        let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "-"
+        return "v\(shortVersion) (\(buildVersion))"
+    }
+
+    func bind(service: any SettingsServicing) {
+        self.service = service
+    }
+
+    func syncConsentState() {
+        hasAITransferConsent = consentStore.hasConsent
+    }
+
+    func requestDeleteAccount() {
+        showDeleteConfirmAlert = true
+    }
+
+    func requestDeleteAccountFinalConfirmation() {
+        showDeleteFinalAlert = true
+    }
+
+    func dismissDeleteError() {
+        deleteErrorMessage = nil
+    }
+
+    func requestConsentRevocation() {
+        showRevokeConsentConfirmAlert = true
+    }
+
+    func revokeAITransferConsent() {
+        consentStore.revokeConsent()
+        hasAITransferConsent = false
+    }
+
+    func deleteMyAccount() async {
+        guard !isDeletingAccount else { return }
+        guard let service else {
+            deleteErrorMessage = "회원 탈퇴를 준비하지 못했어요."
+            return
+        }
+
+        isDeletingAccount = true
+        defer { isDeletingAccount = false }
+
+        let success = await service.deleteMyAccount(reason: nil)
+        guard !success else { return }
+
+        deleteErrorMessage = service.errorMessage ?? "회원 탈퇴 처리 중 문제가 발생했어요."
+    }
+}

--- a/NailClient/NailClient/Features/Settings/Views/SettingsView.swift
+++ b/NailClient/NailClient/Features/Settings/Views/SettingsView.swift
@@ -9,27 +9,95 @@ struct SettingsView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
     @Environment(\.openURL) private var openURL
 
-    @State private var showDeleteConfirmAlert: Bool = false
-    @State private var showDeleteFinalAlert: Bool = false
-    @State private var isDeletingAccount: Bool = false
-    @State private var deleteErrorMessage: String?
     @State private var showMailFallbackAlert: Bool = false
-    @State private var hasAITransferConsent: Bool = false
-    @State private var showRevokeConsentConfirmAlert: Bool = false
-    private let consentStore = AITransferConsentStore.shared
+    @StateObject private var viewModel = SettingsViewModel()
 
-    private var appVersionText: String {
-        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "-"
-        let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "-"
-        return "v\(shortVersion) (\(buildVersion))"
+    var body: some View {
+        SettingsScreen(
+            viewModel: viewModel,
+            onOpenSupportMail: openSupportMail,
+            onOpenURL: { openURL($0) }
+        )
+        .onAppear {
+            viewModel.bind(service: appViewModel)
+            viewModel.syncConsentState()
+        }
+        .alert("회원 탈퇴", isPresented: $viewModel.showDeleteConfirmAlert) {
+            Button("취소", role: .cancel) { }
+            Button("다음", role: .destructive) {
+                viewModel.requestDeleteAccountFinalConfirmation()
+            }
+        } message: {
+            Text("회원 탈퇴를 진행할까요?")
+        }
+        .alert("최종 확인", isPresented: $viewModel.showDeleteFinalAlert) {
+            Button("취소", role: .cancel) { }
+            Button("회원 탈퇴", role: .destructive) {
+                Task {
+                    await viewModel.deleteMyAccount()
+                }
+            }
+        } message: {
+            Text("탈퇴하면 계정을 다시 사용할 수 없어요.")
+        }
+        .alert(
+            "탈퇴 실패",
+            isPresented: Binding(
+                get: { viewModel.deleteErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.dismissDeleteError()
+                    }
+                }
+            )
+        ) {
+            Button("확인", role: .cancel) {
+                viewModel.dismissDeleteError()
+            }
+        } message: {
+            Text(viewModel.deleteErrorMessage ?? "회원 탈퇴 처리 중 문제가 발생했어요.")
+        }
+        .alert("메일 앱을 열 수 없어요", isPresented: $showMailFallbackAlert) {
+            Button("확인", role: .cancel) { }
+        } message: {
+            Text("고객센터 이메일: \(AppConfig.supportEmail)")
+        }
+        .alert("AI 데이터 전송 동의를 철회할까요?", isPresented: $viewModel.showRevokeConsentConfirmAlert) {
+            Button("취소", role: .cancel) { }
+            Button("철회", role: .destructive) {
+                viewModel.revokeAITransferConsent()
+            }
+        } message: {
+            Text("철회 후에는 AI 생성 시 다시 동의해야 합니다.")
+        }
     }
+
+    private func openSupportMail() {
+        let rawEmail = AppConfig.supportEmail
+        let encodedEmail = rawEmail.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed) ?? rawEmail
+
+        guard let url = URL(string: "mailto:\(encodedEmail)") else {
+            showMailFallbackAlert = true
+            return
+        }
+
+        openURL(url) { accepted in
+            if !accepted {
+                showMailFallbackAlert = true
+            }
+        }
+    }
+}
+
+private struct SettingsScreen: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    let onOpenSupportMail: () -> Void
+    let onOpenURL: (URL) -> Void
 
     var body: some View {
         List {
             Section("고객지원") {
-                Button {
-                    openSupportMail()
-                } label: {
+                Button(action: onOpenSupportMail) {
                     rowLabel("고객센터 메일 보내기", trailing: AppConfig.supportEmail)
                 }
                 .buttonStyle(.plain)
@@ -39,7 +107,7 @@ struct SettingsView: View {
                 Section("약관 및 정책") {
                     if let termsURL = AppConfig.termsOfServiceURL {
                         Button {
-                            openURL(termsURL)
+                            onOpenURL(termsURL)
                         } label: {
                             rowLabel("이용약관")
                         }
@@ -48,7 +116,7 @@ struct SettingsView: View {
 
                     if let privacyURL = AppConfig.privacyPolicyURL {
                         Button {
-                            openURL(privacyURL)
+                            onOpenURL(privacyURL)
                         } label: {
                             rowLabel("개인정보처리방침")
                         }
@@ -61,13 +129,13 @@ struct SettingsView: View {
                 HStack {
                     Text("현재 동의 상태")
                     Spacer()
-                    Text(hasAITransferConsent ? "동의됨" : "미동의")
+                    Text(viewModel.hasAITransferConsent ? "동의됨" : "미동의")
                         .foregroundStyle(.secondary)
                 }
 
-                if hasAITransferConsent {
+                if viewModel.hasAITransferConsent {
                     Button(role: .destructive) {
-                        showRevokeConsentConfirmAlert = true
+                        viewModel.requestConsentRevocation()
                     } label: {
                         rowLabel("AI 데이터 전송 동의 철회")
                     }
@@ -83,82 +151,30 @@ struct SettingsView: View {
                 HStack {
                     Text("버전")
                     Spacer()
-                    Text(appVersionText)
+                    Text(viewModel.appVersionText)
                         .foregroundStyle(.secondary)
                 }
             }
 
             Section("계정 관리") {
                 Button(role: .destructive) {
-                    showDeleteConfirmAlert = true
+                    viewModel.requestDeleteAccount()
                 } label: {
                     HStack {
                         Text("회원 탈퇴")
                         Spacer()
-                        if isDeletingAccount {
+                        if viewModel.isDeletingAccount {
                             ProgressView()
                                 .progressViewStyle(.circular)
                         }
                     }
                 }
-                .disabled(isDeletingAccount)
+                .disabled(viewModel.isDeletingAccount)
             }
         }
         .navigationTitle("설정")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            hasAITransferConsent = consentStore.hasConsent
-        }
-        .disabled(isDeletingAccount)
-        .alert("회원 탈퇴", isPresented: $showDeleteConfirmAlert) {
-            Button("취소", role: .cancel) { }
-            Button("다음", role: .destructive) {
-                showDeleteFinalAlert = true
-            }
-        } message: {
-            Text("회원 탈퇴를 진행할까요?")
-        }
-        .alert("최종 확인", isPresented: $showDeleteFinalAlert) {
-            Button("취소", role: .cancel) { }
-            Button("회원 탈퇴", role: .destructive) {
-                Task {
-                    await deleteMyAccount()
-                }
-            }
-        } message: {
-            Text("탈퇴하면 계정을 다시 사용할 수 없어요.")
-        }
-        .alert(
-            "탈퇴 실패",
-            isPresented: Binding(
-                get: { deleteErrorMessage != nil },
-                set: { isPresented in
-                    if !isPresented {
-                        deleteErrorMessage = nil
-                    }
-                }
-            )
-        ) {
-            Button("확인", role: .cancel) {
-                deleteErrorMessage = nil
-            }
-        } message: {
-            Text(deleteErrorMessage ?? "회원 탈퇴 처리 중 문제가 발생했어요.")
-        }
-        .alert("메일 앱을 열 수 없어요", isPresented: $showMailFallbackAlert) {
-            Button("확인", role: .cancel) { }
-        } message: {
-            Text("고객센터 이메일: \(AppConfig.supportEmail)")
-        }
-        .alert("AI 데이터 전송 동의를 철회할까요?", isPresented: $showRevokeConsentConfirmAlert) {
-            Button("취소", role: .cancel) { }
-            Button("철회", role: .destructive) {
-                consentStore.revokeConsent()
-                hasAITransferConsent = false
-            }
-        } message: {
-            Text("철회 후에는 AI 생성 시 다시 동의해야 합니다.")
-        }
+        .disabled(viewModel.isDeletingAccount)
     }
 
     @ViewBuilder
@@ -182,39 +198,17 @@ struct SettingsView: View {
         }
         .fullRowTapTarget(alignment: .leading)
     }
-
-    private func openSupportMail() {
-        let rawEmail = AppConfig.supportEmail
-        let encodedEmail = rawEmail.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed) ?? rawEmail
-
-        guard let url = URL(string: "mailto:\(encodedEmail)") else {
-            showMailFallbackAlert = true
-            return
-        }
-
-        openURL(url) { accepted in
-            if !accepted {
-                showMailFallbackAlert = true
-            }
-        }
-    }
-
-    private func deleteMyAccount() async {
-        guard !isDeletingAccount else { return }
-
-        isDeletingAccount = true
-        defer { isDeletingAccount = false }
-
-        let success = await appViewModel.deleteMyAccount(reason: nil)
-        guard !success else { return }
-
-        deleteErrorMessage = appViewModel.errorMessage ?? "회원 탈퇴 처리 중 문제가 발생했어요."
-    }
 }
 
 #Preview {
     NavigationStack {
         SettingsView()
-            .environmentObject(AppViewModel())
+            .environmentObject(
+                AppViewModel.preview(
+                    route: .home,
+                    currentUser: .preview(nickname: "설정 프리뷰"),
+                    selectedMainTab: .myPage
+                )
+            )
     }
 }

--- a/NailClient/NailClientTests/AINailGenerationDetailItemTests.swift
+++ b/NailClient/NailClientTests/AINailGenerationDetailItemTests.swift
@@ -1,0 +1,47 @@
+//
+//  AINailGenerationDetailItemTests.swift
+//  NailClientTests
+//
+
+import Foundation
+import Testing
+@testable import NailClient
+
+@MainActor
+struct AINailGenerationDetailItemTests {
+    @Test
+    func makeAutoOpenedDetailItem_현재생성상태를상세아이템으로매핑한다() throws {
+        let jobID = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+        let parentJobID = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
+        let createdAt = Date(timeIntervalSince1970: 1_736_000_000)
+        let resultURL = try #require(URL(string: "https://example.com/result.png"))
+
+        let viewModel = AINailGenerationViewModel.previewState(
+            selectedShape: .square,
+            selectedExtensionOption: .extend,
+            resultImageURL: resultURL,
+            currentJobId: jobID,
+            parentJobId: parentJobID,
+            refinementTurn: 2,
+            isSubmitting: false,
+            statusMessage: "생성 완료"
+        )
+
+        let item = try #require(viewModel.makeAutoOpenedDetailItem(createdAt: createdAt))
+        #expect(item.jobId == jobID)
+        #expect(item.fullImageURL == resultURL)
+        #expect(item.thumbnailURL == nil)
+        #expect(item.shape == .square)
+        #expect(item.extensionMode == .extend)
+        #expect(item.createdAt == createdAt)
+        #expect(item.parentJobId == parentJobID)
+        #expect(item.refinementTurn == 2)
+        #expect(item.isLiked == false)
+    }
+
+    @Test
+    func makeAutoOpenedDetailItem_필수값이없으면_nil을반환한다() {
+        let viewModel = AINailGenerationViewModel()
+        #expect(viewModel.makeAutoOpenedDetailItem() == nil)
+    }
+}

--- a/NailClient/NailClientTests/OnboardingProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/OnboardingProfileViewModelTests.swift
@@ -39,8 +39,9 @@ struct OnboardingProfileViewModelTests {
         viewModel.nickname = "tester"
         viewModel.selectedStyles = [.natural]
         viewModel.profileUIImage = makeProfileImage()
+        viewModel.bind(service: appViewModel)
 
-        await viewModel.submit(appViewModel: appViewModel)
+        await viewModel.submit()
 
         let capturedProfileURL = await authService.capturedCompleteOnboardingProfileImageURL()
         let capturedKinds = await authService.capturedUploadKinds()
@@ -83,8 +84,9 @@ struct OnboardingProfileViewModelTests {
         viewModel.nickname = "tester"
         viewModel.selectedStyles = [.natural]
         viewModel.profileUIImage = makeProfileImage()
+        viewModel.bind(service: appViewModel)
 
-        await viewModel.submit(appViewModel: appViewModel)
+        await viewModel.submit()
 
         let capturedProfileURL = await authService.capturedCompleteOnboardingProfileImageURL()
         #expect(capturedProfileURL == fallbackURL)

--- a/NailClient/NailClientTests/ProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/ProfileViewModelTests.swift
@@ -152,8 +152,9 @@ struct ProfileViewModelTests {
         let viewModel = ProfileViewModel()
         viewModel.beginEdit(from: appViewModel.currentUser)
         viewModel.nickname = "after"
+        viewModel.bind(service: appViewModel)
 
-        await viewModel.save(appViewModel: appViewModel)
+        await viewModel.save()
 
         #expect(viewModel.isSaving == false)
         #expect(viewModel.isEditSheetPresented == false)
@@ -188,8 +189,9 @@ struct ProfileViewModelTests {
         let viewModel = ProfileViewModel()
         viewModel.beginEdit(from: appViewModel.currentUser)
         viewModel.nickname = "after"
+        viewModel.bind(service: appViewModel)
 
-        await viewModel.save(appViewModel: appViewModel)
+        await viewModel.save()
 
         #expect(viewModel.isSaving == false)
         #expect(viewModel.isEditSheetPresented == true)

--- a/NailClient/NailClientTests/SettingsViewModelTests.swift
+++ b/NailClient/NailClientTests/SettingsViewModelTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import NailClient
+
+@MainActor
+struct SettingsViewModelTests {
+    @Test
+    func syncConsentState_스토어상태를반영한다() {
+        let consentStore = SettingsConsentStoreSpy(hasConsent: true)
+        let viewModel = SettingsViewModel(consentStore: consentStore)
+
+        viewModel.syncConsentState()
+
+        #expect(viewModel.hasAITransferConsent == true)
+    }
+
+    @Test
+    func revokeAITransferConsent_동의상태를해제한다() {
+        let consentStore = SettingsConsentStoreSpy(hasConsent: true)
+        let viewModel = SettingsViewModel(consentStore: consentStore)
+
+        viewModel.revokeAITransferConsent()
+
+        #expect(viewModel.hasAITransferConsent == false)
+        #expect(consentStore.revokeCallCount == 1)
+    }
+
+    @Test
+    func deleteMyAccount_실패시_에러메시지를노출한다() async {
+        let consentStore = SettingsConsentStoreSpy(hasConsent: false)
+        let service = SettingsServiceSpy(deleteResult: false, errorMessage: "탈퇴 실패")
+        let viewModel = SettingsViewModel(consentStore: consentStore)
+        viewModel.bind(service: service)
+
+        await viewModel.deleteMyAccount()
+
+        #expect(viewModel.isDeletingAccount == false)
+        #expect(viewModel.deleteErrorMessage == "탈퇴 실패")
+    }
+
+    @Test
+    func deleteMyAccount_성공시_에러메시지를남기지않는다() async {
+        let consentStore = SettingsConsentStoreSpy(hasConsent: true)
+        let service = SettingsServiceSpy(deleteResult: true, errorMessage: nil)
+        let viewModel = SettingsViewModel(consentStore: consentStore)
+        viewModel.bind(service: service)
+
+        await viewModel.deleteMyAccount()
+
+        #expect(viewModel.isDeletingAccount == false)
+        #expect(viewModel.deleteErrorMessage == nil)
+        #expect(service.deleteCallCount == 1)
+    }
+}
+
+private final class SettingsConsentStoreSpy: AITransferConsentStoring {
+    var hasConsent: Bool
+    private(set) var revokeCallCount: Int = 0
+
+    init(hasConsent: Bool) {
+        self.hasConsent = hasConsent
+    }
+
+    func revokeConsent() {
+        revokeCallCount += 1
+        hasConsent = false
+    }
+}
+
+@MainActor
+private final class SettingsServiceSpy: SettingsServicing {
+    var errorMessage: String?
+    private let deleteResult: Bool
+    private(set) var deleteCallCount: Int = 0
+
+    init(deleteResult: Bool, errorMessage: String?) {
+        self.deleteResult = deleteResult
+        self.errorMessage = errorMessage
+    }
+
+    func deleteMyAccount(reason: String?) async -> Bool {
+        _ = reason
+        deleteCallCount += 1
+        return deleteResult
+    }
+}


### PR DESCRIPTION
## Summary
- 프로필·설정·온보딩의 앱 상태 의존을 줄이고 화면 상태를 분리했습니다.
- 프리뷰 전용 앱 컨텍스트를 추가해 side effect 없는 프리뷰를 지원했습니다.
- AI 생성 결과 상세 자동 열기와 결과 캐시 갱신 흐름을 정리했습니다.
- AGENTS 규칙과 DerivedData 가이드를 보강했습니다.

## Domain
client-app-ios

## Scope
In scope:
- 프로필·설정·온보딩 화면 상태 분리
- 프리뷰 격리와 AI 결과 상세 자동 열기 흐름 정리
- AI 생성 크롭 화면의 전체 화면 전환 반영
- AI 피팅 상세보기 레이아웃/동작 정리
- AGENTS 문서 보강

Out of scope:
- ViewModel 테스트 구조 개선
- AINailGeneration 대형 화면 추가 분해

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -sdk iphonesimulator build` 성공
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' -only-testing:NailClientTests` 성공

## Risk & Rollback
- Risk: 앱 상태 연결을 줄인 화면에서 회귀가 있으면 화면 진입 시 상태 동기화가 어긋날 수 있습니다.
- Rollback: PR #49를 revert하고 `task/48-ui-layer-refactor-backup` 브랜치를 기준으로 필요한 변경만 다시 적용합니다.

## Related
Related #47
Related #27

## Closes
Closes #48