### PR TITLE
test(viewmodel): 프로필과 온보딩 테스트 구조 정리

### DIFF
--- a/NailClient/NailClientTests/NailClientTests.swift
+++ b/NailClient/NailClientTests/NailClientTests.swift
@@ -464,16 +464,10 @@ struct NailClientTests {
         nickname: String?,
         profileImageURL: String?
     ) -> AppUser {
-        AppUser(
+        AppUser.preview(
             id: UUID(),
-            role: nil,
             nickname: nickname,
-            profileImageURL: profileImageURL,
-            defaultRegionID: nil,
-            defaultRegionLabel: nil,
-            defaultServiceRegionID: nil,
-            createdAt: nil,
-            updatedAt: nil
+            profileImageURL: profileImageURL
         )
     }
 }

--- a/NailClient/NailClientTests/OnboardingProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/OnboardingProfileViewModelTests.swift
@@ -1,110 +1,52 @@
-import Foundation
 import Testing
 import UIKit
 @testable import NailClient
 
 @MainActor
 struct OnboardingProfileViewModelTests {
-
     @Test
     func submit_이미지업로드성공시_업로드URL로완료요청한다() async {
-        let session = AppSession(accessToken: "access", refreshToken: "refresh")
-        let authService = MockOnboardingAuthService(
-            autoLoginResult: AuthResult(
-                session: session,
-                user: makeUser(nickname: "tester", profileImageURL: "https://example.com/old.png"),
-                needsOnboarding: true,
-                onboardingPrefill: nil
-            ),
-            uploadResponse: NailGenUploadURLResponse(
-                bucket: "profile-images-public",
-                jobId: UUID(),
-                objectPath: "user/profile/new.jpg",
-                signedUploadURL: "https://example.com/upload",
-                publicObjectURL: "https://example.com/new-profile.jpg",
-                expiresInSec: 600
-            ),
-            shouldFailUpload: false
+        let uploadedProfileImageURL = "https://example.com/new-profile.jpg"
+        let service = OnboardingProfileServiceSpy(
+            uploadProfileImageResult: .success(uploadedProfileImageURL)
         )
-
-        let appViewModel = AppViewModel(
-            authService: authService,
-            launchTiming: .init(minimumSplashDuration: .zero, autoLoginTimeout: .seconds(1))
-        )
-        await appViewModel.start()
-
         let viewModel = OnboardingProfileViewModel(
             prefill: OnboardingPrefill(nickname: "tester", profileImageURL: "https://example.com/old.png")
         )
         viewModel.nickname = "tester"
         viewModel.selectedStyles = [.natural]
         viewModel.profileUIImage = makeProfileImage()
-        viewModel.bind(service: appViewModel)
+        viewModel.bind(service: service)
 
         await viewModel.submit()
 
-        let capturedProfileURL = await authService.capturedCompleteOnboardingProfileImageURL()
-        let capturedKinds = await authService.capturedUploadKinds()
-        #expect(capturedProfileURL == "https://example.com/new-profile.jpg")
-        #expect(capturedKinds == [.profile])
+        #expect(service.uploadProfileImageCallCount == 1)
+        #expect(service.completeOnboardingCallCount == 1)
+        #expect(service.capturedNicknames == ["tester"])
+        #expect(service.capturedProfileImageURLs == [uploadedProfileImageURL])
         #expect(viewModel.photoUploadNoticeMessage == nil)
     }
 
     @Test
     func submit_이미지업로드실패시_fallbackURL로완료요청하고안내문구를노출한다() async {
-        let session = AppSession(accessToken: "access", refreshToken: "refresh")
-        let authService = MockOnboardingAuthService(
-            autoLoginResult: AuthResult(
-                session: session,
-                user: makeUser(nickname: "tester", profileImageURL: "https://example.com/original.png"),
-                needsOnboarding: true,
-                onboardingPrefill: nil
-            ),
-            uploadResponse: NailGenUploadURLResponse(
-                bucket: "profile-images-public",
-                jobId: UUID(),
-                objectPath: "user/profile/new.jpg",
-                signedUploadURL: "https://example.com/upload",
-                publicObjectURL: "https://example.com/new-profile.jpg",
-                expiresInSec: 600
-            ),
-            shouldFailUpload: true
-        )
-
-        let appViewModel = AppViewModel(
-            authService: authService,
-            launchTiming: .init(minimumSplashDuration: .zero, autoLoginTimeout: .seconds(1))
-        )
-        await appViewModel.start()
-
         let fallbackURL = "https://example.com/original.png"
+        let service = OnboardingProfileServiceSpy(
+            uploadProfileImageResult: .failure(OnboardingProfileServiceSpyError.uploadFailed)
+        )
         let viewModel = OnboardingProfileViewModel(
             prefill: OnboardingPrefill(nickname: "tester", profileImageURL: fallbackURL)
         )
         viewModel.nickname = "tester"
         viewModel.selectedStyles = [.natural]
         viewModel.profileUIImage = makeProfileImage()
-        viewModel.bind(service: appViewModel)
+        viewModel.bind(service: service)
 
         await viewModel.submit()
 
-        let capturedProfileURL = await authService.capturedCompleteOnboardingProfileImageURL()
-        #expect(capturedProfileURL == fallbackURL)
+        #expect(service.uploadProfileImageCallCount == 1)
+        #expect(service.completeOnboardingCallCount == 1)
+        #expect(service.capturedProfileImageURLs == [fallbackURL])
         #expect(viewModel.photoUploadNoticeMessage?.isEmpty == false)
-    }
-
-    private func makeUser(nickname: String?, profileImageURL: String?) -> AppUser {
-        AppUser(
-            id: UUID(),
-            role: nil,
-            nickname: nickname,
-            profileImageURL: profileImageURL,
-            defaultRegionID: nil,
-            defaultRegionLabel: nil,
-            defaultServiceRegionID: nil,
-            createdAt: nil,
-            updatedAt: nil
-        )
     }
 
     private func makeProfileImage() -> UIImage {
@@ -116,139 +58,32 @@ struct OnboardingProfileViewModelTests {
     }
 }
 
-private enum OnboardingMockError: Error {
-    case unsupported
+private enum OnboardingProfileServiceSpyError: Error {
     case uploadFailed
 }
 
-private actor MockOnboardingAuthService: AuthServicing {
-    private let autoLoginResult: AuthResult
-    private let uploadResponse: NailGenUploadURLResponse
-    private let shouldFailUpload: Bool
+@MainActor
+private final class OnboardingProfileServiceSpy: OnboardingProfileServicing {
+    private let uploadProfileImageResult: Result<String, Error>
 
-    private var recordedCompleteOnboardingProfileImageURL: String?
-    private var recordedKinds: [NailGenUploadKind] = []
+    private(set) var uploadProfileImageCallCount: Int = 0
+    private(set) var completeOnboardingCallCount: Int = 0
+    private(set) var capturedNicknames: [String] = []
+    private(set) var capturedProfileImageURLs: [String?] = []
 
-    init(
-        autoLoginResult: AuthResult,
-        uploadResponse: NailGenUploadURLResponse,
-        shouldFailUpload: Bool
-    ) {
-        self.autoLoginResult = autoLoginResult
-        self.uploadResponse = uploadResponse
-        self.shouldFailUpload = shouldFailUpload
+    init(uploadProfileImageResult: Result<String, Error>) {
+        self.uploadProfileImageResult = uploadProfileImageResult
     }
 
-    func capturedCompleteOnboardingProfileImageURL() -> String? {
-        recordedCompleteOnboardingProfileImageURL
+    func uploadProfileImage(imageData: Data) async throws -> String {
+        _ = imageData
+        uploadProfileImageCallCount += 1
+        return try uploadProfileImageResult.get()
     }
 
-    func capturedUploadKinds() -> [NailGenUploadKind] {
-        recordedKinds
+    func completeOnboarding(nickname: String, profileImageURL: String?) async {
+        completeOnboardingCallCount += 1
+        capturedNicknames.append(nickname)
+        capturedProfileImageURLs.append(profileImageURL)
     }
-
-    func tryAutoLogin(traceId: String, timeout: Duration) async throws -> AuthResult? {
-        autoLoginResult
-    }
-
-    func signInWithKakao(traceId: String) async throws -> AuthResult {
-        throw OnboardingMockError.unsupported
-    }
-
-    func signInWithGoogle(traceId: String) async throws -> AuthResult {
-        throw OnboardingMockError.unsupported
-    }
-
-    func signInWithApple(traceId: String) async throws -> AuthResult {
-        throw OnboardingMockError.unsupported
-    }
-
-    func completeOnboarding(
-        traceId: String,
-        session: AppSession,
-        nickname: String,
-        profileImageURL: String?
-    ) async throws -> (user: AppUser, needsOnboarding: Bool, session: AppSession) {
-        let sourceUser = await MainActor.run { autoLoginResult.user }
-        recordedCompleteOnboardingProfileImageURL = profileImageURL
-        let user = await MainActor.run {
-            AppUser(
-                id: sourceUser.id,
-                role: sourceUser.role,
-                nickname: nickname,
-                profileImageURL: profileImageURL,
-                defaultRegionID: nil,
-                defaultRegionLabel: nil,
-                defaultServiceRegionID: nil,
-                createdAt: sourceUser.createdAt,
-                updatedAt: sourceUser.updatedAt
-            )
-        }
-        return (user, false, session)
-    }
-
-    func updateMyProfile(
-        traceId: String,
-        session: AppSession,
-        nickname: String,
-        profileImageURL: String?
-    ) async throws -> (user: AppUser, session: AppSession) {
-        throw OnboardingMockError.unsupported
-    }
-
-    func issueNailGenerationUploadURL(
-        traceId: String,
-        session: AppSession,
-        kind: NailGenUploadKind,
-        ext: String,
-        contentType: String,
-        bytes: Int,
-        jobId: UUID?
-    ) async throws -> (response: NailGenUploadURLResponse, session: AppSession) {
-        recordedKinds.append(kind)
-        return (uploadResponse, session)
-    }
-
-    func uploadImageToSignedURL(
-        traceId: String,
-        signedUploadURL: String,
-        contentType: String,
-        imageData: Data
-    ) async throws {
-        if shouldFailUpload {
-            throw OnboardingMockError.uploadFailed
-        }
-    }
-
-    func createNailGenerationJob(
-        traceId: String,
-        session: AppSession,
-        shape: NailGenShape,
-        extensionMode: NailGenExtensionMode,
-        handObjectPath: String,
-        referenceObjectPath: String
-    ) async throws -> (response: NailGenCreateJobResponse, session: AppSession) {
-        throw OnboardingMockError.unsupported
-    }
-
-    func refineNailGenerationJob(
-        traceId: String,
-        session: AppSession,
-        sourceJobId: UUID,
-        shape: NailGenShape,
-        extensionMode: NailGenExtensionMode
-    ) async throws -> (response: NailGenRefineJobResponse, session: AppSession) {
-        throw OnboardingMockError.unsupported
-    }
-
-    func getNailGenerationJobStatus(
-        traceId: String,
-        session: AppSession,
-        jobId: UUID
-    ) async throws -> (response: NailGenJobStatusResponse, session: AppSession) {
-        throw OnboardingMockError.unsupported
-    }
-
-    func signOut(traceId: String) async {}
-    func clearLocalSession() async {}
 }

--- a/NailClient/NailClientTests/ProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/ProfileViewModelTests.swift
@@ -25,7 +25,7 @@ struct ProfileViewModelTests {
 
     @Test
     func 동일값이면_저장버튼이비활성화된다() {
-        let user = makeUser(nickname: "tester")
+        let user = AppUser.preview(nickname: "tester")
         let viewModel = ProfileViewModel()
 
         viewModel.sync(from: user)
@@ -48,7 +48,7 @@ struct ProfileViewModelTests {
     @Test
     func makeHeaderDisplay_닉네임없으면_기본문구를반환한다() {
         let viewModel = ProfileViewModel()
-        let user = makeUser(nickname: nil)
+        let user = AppUser.preview(nickname: nil)
 
         let display = viewModel.makeHeaderDisplay(from: user)
 
@@ -58,8 +58,8 @@ struct ProfileViewModelTests {
     @Test
     func makeHeaderDisplay_프로필URL이비었거나잘못되면_nil을반환한다() {
         let viewModel = ProfileViewModel()
-        let emptyURLUser = makeUser(nickname: "tester", profileImageURL: " ")
-        let invalidURLUser = makeUser(nickname: "tester", profileImageURL: "https://exam ple.com")
+        let emptyURLUser = AppUser.preview(nickname: "tester", profileImageURL: " ")
+        let invalidURLUser = AppUser.preview(nickname: "tester", profileImageURL: "https://exam ple.com")
 
         let emptyURLDisplay = viewModel.makeHeaderDisplay(from: emptyURLUser)
         let invalidURLDisplay = viewModel.makeHeaderDisplay(from: invalidURLUser)
@@ -71,7 +71,7 @@ struct ProfileViewModelTests {
     @Test
     func makeHeaderDisplay_정상값이면_trim후반영한다() {
         let viewModel = ProfileViewModel()
-        let user = makeUser(
+        let user = AppUser.preview(
             nickname: "  네일매니아  ",
             profileImageURL: " https://example.com/profile.png "
         )
@@ -115,207 +115,85 @@ struct ProfileViewModelTests {
 
     @Test
     func save_성공시_시트를닫고에러를초기화한다() async {
-        let currentSession = AppSession(accessToken: "access", refreshToken: "refresh")
-        let updatedSession = AppSession(accessToken: "access-new", refreshToken: "refresh-new")
-        let currentUser = makeUser(nickname: "before")
-        let updatedUser = AppUser(
-            id: currentUser.id,
-            role: currentUser.role,
-            nickname: "after",
-            profileImageURL: currentUser.profileImageURL,
-            defaultRegionID: nil,
-            defaultRegionLabel: nil,
-            defaultServiceRegionID: nil,
-            createdAt: currentUser.createdAt,
-            updatedAt: currentUser.updatedAt
-        )
-
-        let authService = ProfileMockAuthService(
-            autoLoginResult: AuthResult(
-                session: currentSession,
-                user: currentUser,
-                needsOnboarding: false,
-                onboardingPrefill: nil
-            ),
-            updateResult: .success((updatedUser, updatedSession))
-        )
-
-        let appViewModel = AppViewModel(
-            authService: authService,
-            launchTiming: .init(
-                minimumSplashDuration: .milliseconds(10),
-                autoLoginTimeout: .milliseconds(120)
-            )
-        )
-        await appViewModel.start()
-
+        let currentUser = AppUser.preview(nickname: "before")
+        let service = ProfileServiceSpy(updateMyProfileResult: true)
         let viewModel = ProfileViewModel()
-        viewModel.beginEdit(from: appViewModel.currentUser)
+        viewModel.beginEdit(from: currentUser)
         viewModel.nickname = "after"
-        viewModel.bind(service: appViewModel)
+        viewModel.bind(service: service)
 
         await viewModel.save()
 
         #expect(viewModel.isSaving == false)
         #expect(viewModel.isEditSheetPresented == false)
         #expect(viewModel.saveErrorMessage == nil)
-        #expect(appViewModel.currentUser?.nickname == "after")
+        #expect(service.updateMyProfileCallCount == 1)
+        #expect(service.capturedNicknames == ["after"])
     }
 
     @Test
     func save_실패시_시트를유지하고에러메시지를보여준다() async {
-        let session = AppSession(accessToken: "access", refreshToken: "refresh")
-        let currentUser = makeUser(nickname: "before")
-
-        let authService = ProfileMockAuthService(
-            autoLoginResult: AuthResult(
-                session: session,
-                user: currentUser,
-                needsOnboarding: false,
-                onboardingPrefill: nil
-            ),
-            updateResult: .failure(ProfileMockError.updateFailed)
+        let currentUser = AppUser.preview(nickname: "before")
+        let service = ProfileServiceSpy(
+            updateMyProfileResult: false,
+            errorMessage: "프로필 수정 실패"
         )
-
-        let appViewModel = AppViewModel(
-            authService: authService,
-            launchTiming: .init(
-                minimumSplashDuration: .milliseconds(10),
-                autoLoginTimeout: .milliseconds(120)
-            )
-        )
-        await appViewModel.start()
-
         let viewModel = ProfileViewModel()
-        viewModel.beginEdit(from: appViewModel.currentUser)
+        viewModel.beginEdit(from: currentUser)
         viewModel.nickname = "after"
-        viewModel.bind(service: appViewModel)
+        viewModel.bind(service: service)
 
         await viewModel.save()
 
         #expect(viewModel.isSaving == false)
         #expect(viewModel.isEditSheetPresented == true)
-        #expect(viewModel.saveErrorMessage?.contains("프로필 수정 실패") == true)
+        #expect(viewModel.saveErrorMessage == "프로필 수정 실패")
+        #expect(service.updateMyProfileCallCount == 1)
+        #expect(service.capturedNicknames == ["after"])
     }
-
-    private func makeUser(nickname: String?, profileImageURL: String? = "https://example.com/profile.png") -> AppUser {
-        AppUser(
-            id: UUID(),
-            role: nil,
-            nickname: nickname,
-            profileImageURL: profileImageURL,
-            defaultRegionID: nil,
-            defaultRegionLabel: nil,
-            defaultServiceRegionID: nil,
-            createdAt: nil,
-            updatedAt: nil
-        )
-    }
-
 }
 
-private enum ProfileMockError: Error {
-    case unsupported
-    case updateFailed
-}
+@MainActor
+private final class ProfileServiceSpy: ProfileServicing {
+    var errorMessage: String?
 
-private actor ProfileMockAuthService: AuthServicing {
-    let autoLoginResult: AuthResult?
-    let updateResult: Result<(AppUser, AppSession), Error>
+    private let updateMyProfileResult: Bool
+    private let uploadProfileImageResult: Result<String, Error>
+    private let updateMyProfileImageResult: Bool
 
-    init(autoLoginResult: AuthResult?, updateResult: Result<(AppUser, AppSession), Error>) {
-        self.autoLoginResult = autoLoginResult
-        self.updateResult = updateResult
+    private(set) var updateMyProfileCallCount: Int = 0
+    private(set) var uploadProfileImageCallCount: Int = 0
+    private(set) var updateMyProfileImageCallCount: Int = 0
+    private(set) var capturedNicknames: [String] = []
+    private(set) var capturedProfileImageURLs: [String?] = []
+
+    init(
+        updateMyProfileResult: Bool = true,
+        uploadProfileImageResult: Result<String, Error> = .success("https://example.com/uploaded-profile.png"),
+        updateMyProfileImageResult: Bool = true,
+        errorMessage: String? = nil
+    ) {
+        self.updateMyProfileResult = updateMyProfileResult
+        self.uploadProfileImageResult = uploadProfileImageResult
+        self.updateMyProfileImageResult = updateMyProfileImageResult
+        self.errorMessage = errorMessage
     }
 
-    func tryAutoLogin(traceId: String, timeout: Duration) async throws -> AuthResult? {
-        autoLoginResult
+    func updateMyProfile(nickname: String) async -> Bool {
+        updateMyProfileCallCount += 1
+        capturedNicknames.append(nickname)
+        return updateMyProfileResult
     }
 
-    func signInWithKakao(traceId: String) async throws -> AuthResult {
-        throw ProfileMockError.unsupported
+    func uploadProfileImage(imageData: Data) async throws -> String {
+        _ = imageData
+        uploadProfileImageCallCount += 1
+        return try uploadProfileImageResult.get()
     }
 
-    func signInWithGoogle(traceId: String) async throws -> AuthResult {
-        throw ProfileMockError.unsupported
-    }
-
-    func signInWithApple(traceId: String) async throws -> AuthResult {
-        throw ProfileMockError.unsupported
-    }
-
-    func completeOnboarding(
-        traceId: String,
-        session: AppSession,
-        nickname: String,
-        profileImageURL: String?
-    ) async throws -> (user: AppUser, needsOnboarding: Bool, session: AppSession) {
-        throw ProfileMockError.unsupported
-    }
-
-    func updateMyProfile(
-        traceId: String,
-        session: AppSession,
-        nickname: String,
-        profileImageURL: String?
-    ) async throws -> (user: AppUser, session: AppSession) {
-        let result = try updateResult.get()
-        return (user: result.0, session: result.1)
-    }
-
-    func issueNailGenerationUploadURL(
-        traceId: String,
-        session: AppSession,
-        kind: NailGenUploadKind,
-        ext: String,
-        contentType: String,
-        bytes: Int,
-        jobId: UUID?
-    ) async throws -> (response: NailGenUploadURLResponse, session: AppSession) {
-        throw ProfileMockError.unsupported
-    }
-
-    func uploadImageToSignedURL(
-        traceId: String,
-        signedUploadURL: String,
-        contentType: String,
-        imageData: Data
-    ) async throws {
-        throw ProfileMockError.unsupported
-    }
-
-    func createNailGenerationJob(
-        traceId: String,
-        session: AppSession,
-        shape: NailGenShape,
-        extensionMode: NailGenExtensionMode,
-        handObjectPath: String,
-        referenceObjectPath: String
-    ) async throws -> (response: NailGenCreateJobResponse, session: AppSession) {
-        throw ProfileMockError.unsupported
-    }
-
-    func refineNailGenerationJob(
-        traceId: String,
-        session: AppSession,
-        sourceJobId: UUID,
-        shape: NailGenShape,
-        extensionMode: NailGenExtensionMode
-    ) async throws -> (response: NailGenRefineJobResponse, session: AppSession) {
-        throw ProfileMockError.unsupported
-    }
-
-    func getNailGenerationJobStatus(
-        traceId: String,
-        session: AppSession,
-        jobId: UUID
-    ) async throws -> (response: NailGenJobStatusResponse, session: AppSession) {
-        throw ProfileMockError.unsupported
-    }
-
-    func signOut(traceId: String) async {
-    }
-
-    func clearLocalSession() async {
+    func updateMyProfileImage(profileImageURL: String?) async -> Bool {
+        updateMyProfileImageCallCount += 1
+        capturedProfileImageURLs.append(profileImageURL)
+        return updateMyProfileImageResult
     }
 }


### PR DESCRIPTION
## Summary
- ProfileViewModelTests와 OnboardingProfileViewModelTests를 기능 서비스 spy 기준으로 정리했습니다.
- ViewModel 테스트에서 AppViewModel 부팅 의존을 제거해 테스트 경계를 명확히 했습니다.
- AppUser.preview를 테스트 user fixture로 재사용하도록 맞췄습니다.

## Domain
client-app-ios

## Scope
In scope:
- Profile/Onboarding ViewModel 테스트 경계 정리
- 공통 user fixture를 preview helper로 재사용
- 관련 단위 테스트 검증

Out of scope:
- 런타임 기능 변경
- AINailGeneration 화면 분해
- DB/API 계약 변경

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests` 성공

## Risk & Rollback
- Risk: 테스트 더블을 단순화하면서 AppViewModel 통합 경로를 가리는 범위가 생길 수 있습니다.
- Rollback: PR 전체를 revert하고 기존 AppViewModel 기반 테스트 경로로 되돌립니다.

## Closes
Closes #50