### PR TITLE
fix(ai-generation): 생성 결과 상세 즉시 진입 정리

### DIFF
--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -28,14 +28,9 @@ struct AINailGenerationView: View {
     @State private var handSelectionTask: Task<Void, Never>?
     @State private var referenceSelectionTask: Task<Void, Never>?
     @State private var pushNavigationTask: Task<Void, Never>?
-    @State private var detailResolveTask: Task<Void, Never>?
-    @State private var detailResolveToken: UUID?
     @State private var designSelectionToastTask: Task<Void, Never>?
     @State private var lastAppliedDesignPayloadID: UUID?
     @State private var lastAutoOpenedJobId: UUID?
-    @State private var directDetailOpenSuppressedJobId: UUID?
-    @State private var isResolvingDetailItem: Bool = false
-    @State private var detailResolveAlert: DetailResolveAlert?
     @State private var isConsentSheetPresented: Bool = false
     private let uploadCardSpacing: CGFloat = 12
     private let uploadCardHeight: CGFloat = 180
@@ -72,8 +67,6 @@ struct AINailGenerationView: View {
         .overlay {
             if viewModel.isSubmitting {
                 generationBlockingOverlay
-            } else if isResolvingDetailItem {
-                detailResolvingOverlay
             }
         }
         .overlay(alignment: .top) {
@@ -92,7 +85,7 @@ struct AINailGenerationView: View {
                 await appViewModel.refreshPushAuthorizationState()
             }
             applySelectedDesignIfNeeded(requireAITab: false)
-            autoOpenDetailIfNeeded()
+            presentCurrentResultDetailIfNeeded()
         }
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }
@@ -113,13 +106,13 @@ struct AINailGenerationView: View {
             }
         }
         .onChange(of: viewModel.isSubmitting) { _, _ in
-            autoOpenDetailIfNeeded()
+            presentCurrentResultDetailIfNeeded()
         }
         .onChange(of: viewModel.resultImageURL) { _, _ in
-            autoOpenDetailIfNeeded()
+            presentCurrentResultDetailIfNeeded()
         }
         .onChange(of: appViewModel.selectedMainTab) { _, _ in
-            autoOpenDetailIfNeeded()
+            presentCurrentResultDetailIfNeeded()
         }
         .onDisappear {
             handSelectionTask?.cancel()
@@ -128,10 +121,6 @@ struct AINailGenerationView: View {
             referenceSelectionTask = nil
             pushNavigationTask?.cancel()
             pushNavigationTask = nil
-            detailResolveTask?.cancel()
-            detailResolveTask = nil
-            detailResolveToken = nil
-            isResolvingDetailItem = false
             designSelectionToastTask?.cancel()
             designSelectionToastTask = nil
         }
@@ -199,13 +188,6 @@ struct AINailGenerationView: View {
                 onDelete: {
                     await deleteDetailItem(jobId: item.jobId)
                 }
-            )
-        }
-        .alert(item: $detailResolveAlert) { alert in
-            Alert(
-                title: Text(alert.title),
-                message: Text(alert.message),
-                dismissButton: .default(Text("확인"))
             )
         }
         .fullScreenCover(item: $handCropSource, onDismiss: {
@@ -758,36 +740,6 @@ struct AINailGenerationView: View {
         }
     }
 
-    private var detailResolvingOverlay: some View {
-        ZStack {
-            AIGenerationDesignTokens.generationOverlayScrim
-                .ignoresSafeArea()
-
-            VStack(spacing: 10) {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .tint(AIGenerationDesignTokens.accent)
-                    .controlSize(.regular)
-
-                Text("생성 결과를 불러오는 중...")
-                    .font(.system(AIGenerationDesignTokens.metaStyle, weight: .semibold))
-                    .foregroundStyle(AIGenerationDesignTokens.secondaryText)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
-            .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(AIGenerationDesignTokens.generationModalBackground)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(AIGenerationDesignTokens.border, lineWidth: 1)
-                    )
-            )
-            .padding(.horizontal, 32)
-        }
-    }
-
     private var openResultsTabButton: some View {
         Button {
             appViewModel.syncSelectedMainTab(.results)
@@ -881,73 +833,14 @@ struct AINailGenerationView: View {
         applySelectedDesignIfNeeded(requireAITab: false, showsToast: true)
     }
 
-    private func autoOpenDetailIfNeeded() {
+    private func presentCurrentResultDetailIfNeeded() {
         guard appViewModel.selectedMainTab == .ai else { return }
         guard !viewModel.isSubmitting else { return }
-        guard let jobId = viewModel.currentJobId else { return }
-        guard lastAutoOpenedJobId != jobId else { return }
-        guard directDetailOpenSuppressedJobId != jobId else { return }
         guard let detailItem = viewModel.makeAutoOpenedDetailItem() else { return }
+        guard lastAutoOpenedJobId != detailItem.jobId else { return }
 
         selectedDetailItem = detailItem
-        lastAutoOpenedJobId = jobId
-    }
-
-    private func resolveAndOpenDetail(jobId: UUID) {
-        guard appViewModel.selectedMainTab == .ai else { return }
-        guard lastAutoOpenedJobId != jobId else { return }
-
-        let resolveToken = UUID()
-        detailResolveToken = resolveToken
-        detailResolveTask?.cancel()
-        detailResolveTask = Task { @MainActor in
-            isResolvingDetailItem = true
-            detailResolveAlert = nil
-            defer {
-                if detailResolveToken == resolveToken {
-                    isResolvingDetailItem = false
-                    detailResolveTask = nil
-                    detailResolveToken = nil
-                }
-            }
-
-            let clock = ContinuousClock()
-            let startedAt = clock.now
-
-            while !Task.isCancelled {
-                guard appViewModel.selectedMainTab == .ai else { return }
-
-                do {
-                    let response = try await appViewModel.fetchCompletedNailGenerationList(
-                        limit: 20,
-                        cursor: nil,
-                        likedOnly: false
-                    )
-
-                    if let matched = response.items.first(where: { $0.jobId == jobId }) {
-                        selectedDetailItem = FittedAIImagesViewModel.makeItem(matched)
-                        lastAutoOpenedJobId = jobId
-                        return
-                    }
-                } catch {
-                    // 목록 동기화 지연/일시 오류는 최대 대기시간 내 재시도
-                }
-
-                if startedAt.duration(to: clock.now) >= .seconds(30) {
-                    detailResolveAlert = DetailResolveAlert(
-                        title: "상세 불러오기 실패",
-                        message: "생성 결과를 아직 찾지 못했어요. 잠시 후 다시 확인해 주세요."
-                    )
-                    return
-                }
-
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
-            }
-        }
+        lastAutoOpenedJobId = detailItem.jobId
     }
 
     private func loadDetailImageSet(
@@ -1114,11 +1007,10 @@ struct AINailGenerationView: View {
             return
         }
 
-        directDetailOpenSuppressedJobId = jobId
         let outcome = await viewModel.openResultFromPush(jobId: jobId)
         switch outcome {
         case .opened:
-            resolveAndOpenDetail(jobId: jobId)
+            presentCurrentResultDetailIfNeeded()
         case .inProgress(let message):
             appViewModel.updateAIGenerationProgress(message: message)
         case .failed(let message):
@@ -1127,12 +1019,6 @@ struct AINailGenerationView: View {
         appViewModel.consumePushNavigationRequest()
     }
 
-}
-
-private struct DetailResolveAlert: Identifiable {
-    let id: UUID = UUID()
-    let title: String
-    let message: String
 }
 
 private struct HandCropSource: Identifiable {

--- a/NailClient/NailClientTests/AINailGenerationPushOpenTests.swift
+++ b/NailClient/NailClientTests/AINailGenerationPushOpenTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import NailClient
+
+@MainActor
+struct AINailGenerationPushOpenTests {
+    @Test
+    func openResultFromPush_완료응답시_resultImageURL와_job메타를설정한다() async {
+        let jobId = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+        let parentJobId = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
+        let resultImageURL = "https://example.com/push-result.png"
+        let service = PushOpenAINailGenerationServiceSpy(
+            statusResponse: NailGenJobStatusResponse(
+                status: .completed,
+                resultImageURL: resultImageURL,
+                errorCode: nil,
+                errorMessage: nil,
+                parentJobId: parentJobId.uuidString,
+                refinementTurn: 2,
+                canRefine: true
+            )
+        )
+        let viewModel = AINailGenerationViewModel(service: service)
+
+        let outcome = await viewModel.openResultFromPush(jobId: jobId)
+
+        #expect(outcome == .opened)
+        #expect(viewModel.currentJobId == jobId)
+        #expect(viewModel.resultImageURL?.absoluteString == resultImageURL)
+        #expect(viewModel.parentJobId == parentJobId)
+        #expect(viewModel.refinementTurn == 2)
+        #expect(viewModel.canRefine == false)
+        #expect(viewModel.statusMessage == "생성 완료")
+        #expect(viewModel.errorMessage == nil)
+        #expect(service.statusCallCount == 1)
+    }
+
+    @Test
+    func makeAutoOpenedDetailItem_푸시로열린완료상태를즉시상세아이템으로매핑한다() async throws {
+        let jobId = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+        let parentJobId = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+        let createdAt = Date(timeIntervalSince1970: 1_736_000_123)
+        let resultImageURL = "https://example.com/push-opened.png"
+        let service = PushOpenAINailGenerationServiceSpy(
+            statusResponse: NailGenJobStatusResponse(
+                status: .completed,
+                resultImageURL: resultImageURL,
+                errorCode: nil,
+                errorMessage: nil,
+                parentJobId: parentJobId.uuidString,
+                refinementTurn: 1,
+                canRefine: false
+            )
+        )
+        let viewModel = AINailGenerationViewModel(service: service)
+        viewModel.selectedShape = .square
+        viewModel.selectedExtensionOption = .extend
+
+        let outcome = await viewModel.openResultFromPush(jobId: jobId)
+        let item = try #require(viewModel.makeAutoOpenedDetailItem(createdAt: createdAt))
+
+        #expect(outcome == .opened)
+        #expect(item.jobId == jobId)
+        #expect(item.fullImageURL?.absoluteString == resultImageURL)
+        #expect(item.thumbnailURL == nil)
+        #expect(item.shape == .square)
+        #expect(item.extensionMode == .extend)
+        #expect(item.createdAt == createdAt)
+        #expect(item.parentJobId == parentJobId)
+        #expect(item.refinementTurn == 1)
+        #expect(item.isLiked == false)
+    }
+}
+
+@MainActor
+private final class PushOpenAINailGenerationServiceSpy: AINailGenerationServicing {
+    private let statusResponse: NailGenJobStatusResponse
+    private(set) var statusCallCount: Int = 0
+
+    init(statusResponse: NailGenJobStatusResponse) {
+        self.statusResponse = statusResponse
+    }
+
+    func issueNailGenerationUploadURL(
+        kind: NailGenUploadKind,
+        ext: String,
+        contentType: String,
+        bytes: Int,
+        jobId: UUID?
+    ) async throws -> NailGenUploadURLResponse {
+        _ = kind
+        _ = ext
+        _ = contentType
+        _ = bytes
+        return NailGenUploadURLResponse(
+            bucket: "preview",
+            jobId: jobId ?? UUID(),
+            objectPath: "preview/object.jpg",
+            signedUploadURL: "https://example.com/upload",
+            publicObjectURL: nil,
+            expiresInSec: 600
+        )
+    }
+
+    func uploadImageToSignedURL(
+        signedUploadURL: String,
+        contentType: String,
+        imageData: Data
+    ) async throws {
+        _ = signedUploadURL
+        _ = contentType
+        _ = imageData
+    }
+
+    func createNailGenerationJob(
+        shape: NailGenShape,
+        extensionMode: NailGenExtensionMode,
+        handObjectPath: String,
+        referenceObjectPath: String
+    ) async throws -> NailGenCreateJobResponse {
+        _ = shape
+        _ = extensionMode
+        _ = handObjectPath
+        _ = referenceObjectPath
+        return NailGenCreateJobResponse(
+            jobId: UUID(),
+            status: .queued,
+            pollAfterMs: 0
+        )
+    }
+
+    func getNailGenerationJobStatus(jobId: UUID) async throws -> NailGenJobStatusResponse {
+        _ = jobId
+        statusCallCount += 1
+        return statusResponse
+    }
+}


### PR DESCRIPTION
## Summary
- AI 생성 결과 상세 진입에서 남아 있던 목록 폴링 기반 resolve 흐름을 제거했습니다.
- 생성 완료와 푸시 진입 모두 현재 결과를 즉시 상세 시트로 여는 단일 경로로 정리했습니다.
- 푸시 결과 즉시 오픈 매핑을 검증하는 테스트 2개를 추가했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `AINailGenerationView`의 상세 resolve 상태 및 폴링 제거
- 생성 완료/푸시 완료 시 즉시 상세 오픈 경로 통일
- `AINailGenerationPushOpenTests` 추가

Out of scope:
- `#47` 크롭 화면 하단 잘림 후속 QA
- AI 생성 화면의 대형 구조 분해
- 상세 시트의 라벨/하트 배치 재디자인

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bash scripts/ios-warning-gate.sh`

## Risk & Rollback
- Risk: 생성 완료 직후와 푸시 진입 시 상세 시트 중복 오픈 조건이 남아 있을 수 있습니다.
- Rollback: `AINailGenerationView`의 이번 커밋을 되돌리고 기존 resolve 흐름으로 복원합니다.

## Closes
Closes #46