### PR TITLE
refactor(profile): AI 피팅 결과 그리드 이미지 로딩 성능 개선

### DIFF
--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -94,6 +94,7 @@ final class AppViewModel: ObservableObject {
     private let edgeAPIClient = EdgeAPIClient()
     private let pushManager: any PushNotificationManaging
     private let launchTiming: LaunchTiming
+    private let imagePrefetch: NailImagePrefetchClosure
     private let launchTraceId: String
 
     private var didStart: Bool = false
@@ -114,6 +115,7 @@ final class AppViewModel: ObservableObject {
     init(
         authService: (any AuthServicing)? = nil,
         pushManager: (any PushNotificationManaging)? = nil,
+        imagePrefetch: @escaping NailImagePrefetchClosure = NailImagePipeline.prefetch,
         launchTiming: LaunchTiming = .init(
             minimumSplashDuration: .milliseconds(400),
             autoLoginTimeout: .seconds(5)
@@ -121,6 +123,7 @@ final class AppViewModel: ObservableObject {
     ) {
         self.authService = authService ?? AuthService()
         self.pushManager = pushManager ?? PushNotificationManager.shared
+        self.imagePrefetch = imagePrefetch
         self.launchTiming = launchTiming
         self.launchTraceId = AppLog.makeErrorId()
         bindPushManagerCallbacks()
@@ -878,6 +881,18 @@ final class AppViewModel: ObservableObject {
                 limit: key.limit,
                 likedOnly: key.likedOnly
             )
+            let prefetchURLs = Array(
+                response.items
+                    .compactMap(Self.thumbnailPrefetchURL(from:))
+                    .uniqued()
+                    .prefix(12)
+            )
+            imagePrefetch(
+                prefetchURLs,
+                nil,
+                .fill,
+                .diskCache
+            )
             let traceId = AppLog.makeErrorId()
             AppLog.api.debug(
                 "\(AppLog.prefix(traceId, "API")) nail-gen-list preload_success likedOnly=\(key.likedOnly, privacy: .public) limit=\(key.limit, privacy: .public)"
@@ -1078,5 +1093,28 @@ final class AppViewModel: ObservableObject {
         self.pushAuthorizationState = pushAuthorizationState
         didStart = true
         didLogFirstFrame = true
+    }
+
+    private static func thumbnailPrefetchURL(from item: NailGenListItemResponse) -> URL? {
+        if let rawThumbnailURL = item.thumbnailImageURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawThumbnailURL.isEmpty,
+           let url = URL(string: rawThumbnailURL) {
+            return url
+        }
+
+        if let rawResultURL = item.resultImageURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawResultURL.isEmpty,
+           let url = URL(string: rawResultURL) {
+            return url
+        }
+
+        return nil
+    }
+}
+
+private extension Sequence where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen: Set<Element> = []
+        return filter { seen.insert($0).inserted }
     }
 }

--- a/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
+++ b/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreGraphics
 import Nuke
 
-enum NailImageResizeMode {
+enum NailImageResizeMode: Hashable, Sendable {
     case fill
     case fit
 
@@ -24,6 +24,18 @@ enum NailImageResizeMode {
         }
     }
 }
+
+enum NailImagePrefetchDestination: Hashable, Sendable {
+    case diskCache
+    case memoryCache
+}
+
+typealias NailImagePrefetchClosure = @MainActor @Sendable (
+    _ urls: [URL],
+    _ targetSize: CGSize?,
+    _ resizeMode: NailImageResizeMode,
+    _ destination: NailImagePrefetchDestination
+) -> Void
 
 enum NailImagePipeline {
     private static let memoryCacheLimitBytes = 64 * 1024 * 1024
@@ -62,7 +74,8 @@ enum NailImagePipeline {
         return ImagePipeline(configuration: configuration)
     }()
 
-    private static let prefetcher = ImagePrefetcher(pipeline: shared, destination: .diskCache)
+    private static let diskPrefetcher = ImagePrefetcher(pipeline: shared, destination: .diskCache)
+    private static let memoryPrefetcher = ImagePrefetcher(pipeline: shared, destination: .memoryCache)
 
     static func makeRequest(
         url: URL?,
@@ -92,12 +105,18 @@ enum NailImagePipeline {
     static func prefetch(
         urls: [URL],
         targetSize: CGSize? = nil,
-        resizeMode: NailImageResizeMode = .fill
+        resizeMode: NailImageResizeMode = .fill,
+        destination: NailImagePrefetchDestination = .diskCache
     ) {
         let requests = urls.compactMap {
             makeRequest(url: $0, targetSize: targetSize, resizeMode: resizeMode)
         }
         guard !requests.isEmpty else { return }
-        prefetcher.startPrefetching(with: requests)
+        switch destination {
+        case .diskCache:
+            diskPrefetcher.startPrefetching(with: requests)
+        case .memoryCache:
+            memoryPrefetcher.startPrefetching(with: requests)
+        }
     }
 }

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -83,6 +83,13 @@ final class FittedAIImagesViewModel: ObservableObject {
         case restoreOnCancellation
     }
 
+    private struct ThumbnailPrefetchKey: Hashable {
+        let url: URL
+        let width: Int
+        let height: Int
+        let destination: NailImagePrefetchDestination
+    }
+
     private struct FetchPageResult {
         let response: NailGenListResponse
         let items: [FittedAIImageItem]
@@ -102,8 +109,9 @@ final class FittedAIImagesViewModel: ObservableObject {
     }
 
     private static let listLoadErrorMessage = "이미지 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
-    private static let thumbnailPrefetchCount: Int = 12
-    private static let thumbnailPrefetchSize = CGSize(width: 180, height: 180)
+    private static let leadingThumbnailPrefetchCount: Int = 12
+    private static let appendedThumbnailPrefetchCount: Int = 12
+    private static let nearFutureThumbnailPrefetchCount: Int = 9
 
     struct DetailImageSet: Equatable {
         let generatedURL: URL?
@@ -168,6 +176,7 @@ final class FittedAIImagesViewModel: ObservableObject {
     @Published private(set) var likingJobIDs: Set<UUID> = []
 
     private weak var service: (any FittedAIImagesServicing)?
+    private let imagePrefetch: NailImagePrefetchClosure
     private let pageSize: Int
     private var allNextCursor: String?
     private var likedNextCursor: String?
@@ -176,9 +185,15 @@ final class FittedAIImagesViewModel: ObservableObject {
     private var allLoadGeneration: Int = 0
     private var likedLoadGeneration: Int = 0
     private var inFlightPageFetchTasks: [PageFetchKey: Task<FetchPageResult, Error>] = [:]
+    private var thumbnailTargetSize: CGSize?
+    private var thumbnailPrefetchKeys: Set<ThumbnailPrefetchKey> = []
 
-    init(pageSize: Int = 20) {
+    init(
+        pageSize: Int = 20,
+        imagePrefetch: @escaping NailImagePrefetchClosure = NailImagePipeline.prefetch
+    ) {
         self.pageSize = max(1, min(pageSize, 50))
+        self.imagePrefetch = imagePrefetch
     }
 
     var items: [FittedAIImageItem] {
@@ -225,6 +240,15 @@ final class FittedAIImagesViewModel: ObservableObject {
         self.service = service
     }
 
+    func updateThumbnailTargetSize(_ targetSize: CGSize) {
+        let normalized = Self.normalizedThumbnailTargetSize(targetSize)
+        guard let normalized else { return }
+        guard thumbnailTargetSize != normalized else { return }
+        thumbnailTargetSize = normalized
+        thumbnailPrefetchKeys.removeAll()
+        prefetchLeadingThumbnails(for: selectedFilter)
+    }
+
     func loadIfNeeded() async {
         guard !currentDidLoad else { return }
         await loadInitial(for: selectedFilter, force: false)
@@ -236,6 +260,8 @@ final class FittedAIImagesViewModel: ObservableObject {
 
         if !didLoad(filter: filter) {
             await loadInitial(for: filter, force: false)
+        } else {
+            prefetchLeadingThumbnails(for: filter)
         }
     }
 
@@ -278,6 +304,15 @@ final class FittedAIImagesViewModel: ObservableObject {
             setError(Self.listLoadErrorMessage, for: filter)
             setDidLoad(true, for: filter)
         }
+    }
+
+    func prefetchNearFutureThumbnails(currentItemID: UUID) {
+        guard let targetSize = thumbnailTargetSize else { return }
+        let currentItems = items(for: selectedFilter)
+        guard let index = currentItems.firstIndex(where: { $0.id == currentItemID }) else { return }
+
+        let nextItems = currentItems.dropFirst(index + 1).prefix(Self.nearFutureThumbnailPrefetchCount)
+        prefetchThumbnailItems(Array(nextItems), targetSize: targetSize, destination: .memoryCache)
     }
 
     func isDeleting(jobId: UUID) -> Bool {
@@ -575,26 +610,75 @@ final class FittedAIImagesViewModel: ObservableObject {
         for filter: ListFilter,
         replaceItems: Bool
     ) {
+        let previousItems = items(for: filter)
+        let appendedItems: [FittedAIImageItem]
         if replaceItems {
             setItems(result.items, for: filter)
+            appendedItems = result.items
         } else {
-            let existing = Set(items(for: filter).map(\.jobId))
-            let appended = items(for: filter) + result.items.filter { !existing.contains($0.jobId) }
+            let existing = Set(previousItems.map(\.jobId))
+            let newItems = result.items.filter { !existing.contains($0.jobId) }
+            let appended = previousItems + newItems
             setItems(appended, for: filter)
+            appendedItems = newItems
         }
 
-        prefetchInitialThumbnails(for: filter)
+        if replaceItems {
+            prefetchLeadingThumbnails(for: filter)
+        } else {
+            prefetchAppendedThumbnails(appendedItems)
+        }
         setNextCursor(result.nextCursor, for: filter)
     }
 
-    private func prefetchInitialThumbnails(for filter: ListFilter) {
-        let urls = Array(items(for: filter).prefix(Self.thumbnailPrefetchCount))
-            .compactMap { $0.imageURL }
-        NailImagePipeline.prefetch(
-            urls: urls,
-            targetSize: Self.thumbnailPrefetchSize,
-            resizeMode: .fill
+    private func prefetchLeadingThumbnails(for filter: ListFilter) {
+        guard let targetSize = thumbnailTargetSize else { return }
+        let leadingItems = Array(items(for: filter).prefix(Self.leadingThumbnailPrefetchCount))
+        prefetchThumbnailItems(leadingItems, targetSize: targetSize, destination: .memoryCache)
+    }
+
+    private func prefetchAppendedThumbnails(_ appendedItems: [FittedAIImageItem]) {
+        guard let targetSize = thumbnailTargetSize else { return }
+        let prioritizedItems = Array(appendedItems.prefix(Self.appendedThumbnailPrefetchCount))
+        prefetchThumbnailItems(prioritizedItems, targetSize: targetSize, destination: .memoryCache)
+    }
+
+    private func prefetchThumbnailItems(
+        _ items: [FittedAIImageItem],
+        targetSize: CGSize,
+        destination: NailImagePrefetchDestination
+    ) {
+        let normalizedSize = Self.normalizedThumbnailTargetSize(targetSize)
+        guard let normalizedSize else { return }
+
+        var urlsToPrefetch: [URL] = []
+        for url in items.compactMap(\.imageURL) {
+            let key = ThumbnailPrefetchKey(
+                url: url,
+                width: Int(normalizedSize.width),
+                height: Int(normalizedSize.height),
+                destination: destination
+            )
+
+            guard thumbnailPrefetchKeys.insert(key).inserted else { continue }
+            urlsToPrefetch.append(url)
+        }
+
+        guard !urlsToPrefetch.isEmpty else { return }
+        imagePrefetch(
+            urlsToPrefetch,
+            normalizedSize,
+            .fill,
+            destination
         )
+    }
+
+    private static func normalizedThumbnailTargetSize(_ targetSize: CGSize?) -> CGSize? {
+        guard let targetSize else { return nil }
+        let width = floor(targetSize.width)
+        let height = floor(targetSize.height)
+        guard width > 0, height > 0 else { return nil }
+        return CGSize(width: width, height: height)
     }
 
     private func makeSnapshot(for filter: ListFilter) -> ListStateSnapshot {

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesLayoutMetrics.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesLayoutMetrics.swift
@@ -1,0 +1,36 @@
+//
+//  FittedAIImagesLayoutMetrics.swift
+//  NailClient
+//
+
+import SwiftUI
+
+struct FittedAIImagesLayoutMetrics: Equatable {
+    static let fallbackContainerWidth: CGFloat = 390
+
+    let columnCount: Int
+    let spacing: CGFloat
+    let containerWidth: CGFloat
+    let tileSide: CGFloat
+
+    var thumbnailTargetSize: CGSize {
+        CGSize(width: tileSide, height: tileSide)
+    }
+
+    init(
+        containerWidth: CGFloat,
+        columnCount: Int = 3,
+        spacing: CGFloat = 1
+    ) {
+        let resolvedColumnCount = max(columnCount, 1)
+        let resolvedSpacing = max(spacing, 0)
+        let resolvedWidth = max(containerWidth, 0)
+        let totalSpacing = resolvedSpacing * CGFloat(resolvedColumnCount - 1)
+        let availableWidth = max(resolvedWidth - totalSpacing, 0)
+
+        self.columnCount = resolvedColumnCount
+        self.spacing = resolvedSpacing
+        self.containerWidth = resolvedWidth
+        self.tileSide = floor(availableWidth / CGFloat(resolvedColumnCount))
+    }
+}

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -11,6 +11,7 @@ struct FittedAIImagesView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
     @StateObject private var viewModel: FittedAIImagesViewModel
     @State private var selectedItem: FittedAIImagesViewModel.FittedAIImageItem?
+    @State private var gridContainerWidth: CGFloat = FittedAIImagesLayoutMetrics.fallbackContainerWidth
     private let loadsOnTask: Bool
     private let gridSpacing: CGFloat = 1
     private let tileCornerRadius: CGFloat = 0
@@ -38,6 +39,14 @@ struct FittedAIImagesView: View {
         ]
     }
 
+    private var layoutMetrics: FittedAIImagesLayoutMetrics {
+        FittedAIImagesLayoutMetrics(
+            containerWidth: gridContainerWidth,
+            columnCount: gridColumns.count,
+            spacing: gridSpacing
+        )
+    }
+
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 14) {
@@ -54,6 +63,9 @@ struct FittedAIImagesView: View {
         .scrollBounceBehavior(.always, axes: .vertical)
         .refreshable {
             await viewModel.refresh()
+        }
+        .task(id: layoutMetrics.thumbnailTargetSize) {
+            viewModel.updateThumbnailTargetSize(layoutMetrics.thumbnailTargetSize)
         }
         .task {
             guard loadsOnTask else { return }
@@ -124,6 +136,7 @@ struct FittedAIImagesView: View {
             ForEach(viewModel.items) { item in
                 listRow(item)
                     .onAppear {
+                        viewModel.prefetchNearFutureThumbnails(currentItemID: item.id)
                         Task {
                             await viewModel.loadMoreIfNeeded(currentItemID: item.id)
                         }
@@ -131,6 +144,17 @@ struct FittedAIImagesView: View {
             }
         }
         .padding(.horizontal, -16)
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .task(id: proxy.size.width) {
+                        let measuredWidth = max(proxy.size.width, 0)
+                        guard measuredWidth > 0 else { return }
+                        guard abs(gridContainerWidth - measuredWidth) > 0.5 else { return }
+                        gridContainerWidth = measuredWidth
+                    }
+            }
+        }
     }
 
     private var loadingState: some View {
@@ -293,7 +317,7 @@ struct FittedAIImagesView: View {
     private func thumbnail(_ item: FittedAIImagesViewModel.FittedAIImageItem) -> some View {
         NailRemoteImage(
             url: item.imageURL,
-            targetSize: CGSize(width: 180, height: 180),
+            targetSize: layoutMetrics.thumbnailTargetSize,
             resizeMode: .fill
         ) { phase in
             ZStack {

--- a/NailClient/NailClientTests/App/NailClientTests.swift
+++ b/NailClient/NailClientTests/App/NailClientTests.swift
@@ -93,6 +93,54 @@ struct NailClientTests {
     }
 
     @Test
+    func start_홈진입시_첫12개썸네일rawbytes를디스크프리패치한다() async throws {
+        let session = AppTestFixtures.makeSession()
+        let user = AppTestFixtures.makeUser(nickname: "prefetch-user", profileImageURL: nil)
+        let authResult = AppTestFixtures.makeAuthResult(
+            session: session,
+            user: user,
+            needsOnboarding: false
+        )
+        let listResponse = NailGenListResponse(
+            items: (0..<15).map { index in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: UUID(),
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/result-\(index).jpg",
+                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                )
+            },
+            nextCursor: "next-page"
+        )
+        let recorder = ImagePrefetchRecorder()
+        let viewModel = AppViewModel(
+            authService: MockAuthService(
+                behavior: .immediate(authResult),
+                completedNailGenerationListBehavior: .success(
+                    response: listResponse,
+                    session: session
+                )
+            ),
+            imagePrefetch: recorder.prefetch,
+            launchTiming: .init(
+                minimumSplashDuration: .milliseconds(10),
+                autoLoginTimeout: .milliseconds(120)
+            )
+        )
+
+        await viewModel.start()
+
+        #expect(recorder.calls.count == 1)
+        let call = try #require(recorder.calls.first)
+        #expect(call.urls.count == 12)
+        #expect(call.urls == (0..<12).compactMap { URL(string: "https://example.com/thumb-\($0).jpg") })
+        #expect(call.targetSize == nil)
+        #expect(call.resizeMode == .fill)
+        #expect(call.destination == .diskCache)
+    }
+
+    @Test
     func start_온보딩필요시_온보딩으로이동한다() async {
         let user = AppTestFixtures.makeUser(
             nickname: "new-user",

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesLayoutMetricsTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesLayoutMetricsTests.swift
@@ -1,0 +1,30 @@
+import CoreGraphics
+import Testing
+@testable import NailClient
+
+struct FittedAIImagesLayoutMetricsTests {
+    @Test
+    func 아이폰390폭에서_3열타일크기를실측기반으로계산한다() {
+        let metrics = FittedAIImagesLayoutMetrics(
+            containerWidth: 390,
+            columnCount: 3,
+            spacing: 1
+        )
+
+        #expect(metrics.tileSide == 129)
+        #expect(metrics.thumbnailTargetSize == CGSize(width: 129, height: 129))
+        #expect(metrics.thumbnailTargetSize.width != 180)
+    }
+
+    @Test
+    func 아이폰430폭에서_3열타일크기를실측기반으로계산한다() {
+        let metrics = FittedAIImagesLayoutMetrics(
+            containerWidth: 430,
+            columnCount: 3,
+            spacing: 1
+        )
+
+        #expect(metrics.tileSide == 142)
+        #expect(metrics.thumbnailTargetSize == CGSize(width: 142, height: 142))
+    }
+}

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
@@ -3,6 +3,7 @@
 //  NailClientTests
 //
 
+import CoreGraphics
 import Foundation
 import Testing
 @testable import NailClient
@@ -479,4 +480,191 @@ struct FittedAIImagesViewModelTests {
         #expect(item.generatedImageURLForDetail?.absoluteString == fullURL)
     }
 
+    @Test
+    func 캐시히트후_썸네일크기설정시_앞12개를메모리프리패치한다() async throws {
+        let cachedResponse = NailGenListResponse(
+            items: (0..<15).map { index in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: UUID(uuidString: String(format: "aaaaaaaa-aaaa-4aaa-8aaa-%012d", index + 1)) ?? UUID(),
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                )
+            },
+            nextCursor: nil
+        )
+
+        let gate = AsyncGate()
+        let service = FittedAIImagesServiceSpy(listResponse: cachedResponse)
+        service.cachedFirstPageResponses[.init(limit: 20, likedOnly: false)] = cachedResponse
+        service.fetchHandler = { _, _, _, _ in
+            await gate.wait()
+            return cachedResponse
+        }
+
+        let recorder = ImagePrefetchRecorder()
+        let viewModel = FittedAIImagesViewModel(imagePrefetch: recorder.prefetch)
+        viewModel.bind(service: service)
+
+        let loadTask = Task {
+            await viewModel.loadIfNeeded()
+        }
+
+        for _ in 0..<50 {
+            if viewModel.items.count == cachedResponse.items.count {
+                break
+            }
+            await Task.yield()
+        }
+
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        let call = try #require(recorder.calls.first)
+        #expect(call.urls.count == 12)
+        #expect(call.targetSize == CGSize(width: 129, height: 129))
+        #expect(call.destination == .memoryCache)
+
+        await gate.open()
+        await loadTask.value
+
+        #expect(recorder.calls.count == 1)
+    }
+
+    @Test
+    func loadMore후에는_append된아이템을우선메모리프리패치한다() async throws {
+        let initialIDs = (0..<10).map {
+            UUID(uuidString: String(format: "bbbbbbbb-bbbb-4bbb-8bbb-%012d", $0 + 1)) ?? UUID()
+        }
+        let appendedIDs = (0..<4).map {
+            UUID(uuidString: String(format: "cccccccc-cccc-4ccc-8ccc-%012d", $0 + 1)) ?? UUID()
+        }
+
+        let initialResponse = NailGenListResponse(
+            items: initialIDs.enumerated().map { index, id in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: id,
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-initial-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-initial-\(index).jpg"
+                )
+            },
+            nextCursor: "cursor-next"
+        )
+        let loadMoreResponse = NailGenListResponse(
+            items: appendedIDs.enumerated().map { index, id in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: id,
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-appended-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-appended-\(index).jpg"
+                )
+            },
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchHandler = { call, _, cursor, _ in
+            switch call {
+            case 1:
+                #expect(cursor == nil)
+                return initialResponse
+            case 2:
+                #expect(cursor == "cursor-next")
+                return loadMoreResponse
+            default:
+                return loadMoreResponse
+            }
+        }
+
+        let recorder = ImagePrefetchRecorder()
+        let viewModel = FittedAIImagesViewModel(imagePrefetch: recorder.prefetch)
+        viewModel.bind(service: service)
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        await viewModel.loadIfNeeded()
+        recorder.reset()
+
+        let currentItemID = try #require(initialIDs.last)
+        await viewModel.loadMoreIfNeeded(currentItemID: currentItemID)
+
+        let call = try #require(recorder.calls.first)
+        #expect(call.urls.map(\.absoluteString) == appendedIDs.enumerated().map { index, _ in
+            "https://example.com/thumb-appended-\(index).jpg"
+        })
+        #expect(call.destination == .memoryCache)
+        #expect(call.targetSize == CGSize(width: 129, height: 129))
+    }
+
+    @Test
+    func 셀appear시_현재인덱스이후9개를근접구간으로프리패치한다() async throws {
+        let response = NailGenListResponse(
+            items: (0..<20).map { index in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: UUID(uuidString: String(format: "dddddddd-dddd-4ddd-8ddd-%012d", index + 1)) ?? UUID(),
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                )
+            },
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: response)
+        let recorder = ImagePrefetchRecorder()
+        let viewModel = FittedAIImagesViewModel(imagePrefetch: recorder.prefetch)
+        viewModel.bind(service: service)
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        await viewModel.loadIfNeeded()
+        recorder.reset()
+
+        let currentItemID = try #require(viewModel.items[safe: 11]?.jobId)
+        viewModel.prefetchNearFutureThumbnails(currentItemID: currentItemID)
+
+        let call = try #require(recorder.calls.first)
+        #expect(call.urls.map(\.absoluteString) == (12..<20).map { "https://example.com/thumb-\($0).jpg" })
+        #expect(call.destination == .memoryCache)
+    }
+
+    @Test
+    func 근접구간프리패치는_같은요청을반복호출해도_중복실행하지않는다() async {
+        let response = NailGenListResponse(
+            items: (0..<20).map { index in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: UUID(uuidString: String(format: "eeeeeeee-eeee-4eee-8eee-%012d", index + 1)) ?? UUID(),
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                )
+            },
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: response)
+        let recorder = ImagePrefetchRecorder()
+        let viewModel = FittedAIImagesViewModel(imagePrefetch: recorder.prefetch)
+        viewModel.bind(service: service)
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        await viewModel.loadIfNeeded()
+        recorder.reset()
+
+        let currentItemID = response.items[11].jobId
+        viewModel.prefetchNearFutureThumbnails(currentItemID: currentItemID)
+        viewModel.prefetchNearFutureThumbnails(currentItemID: currentItemID)
+
+        #expect(recorder.calls.count == 1)
+    }
+
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
 }

--- a/NailClient/NailClientTests/Features/Profile/ProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/ProfileViewModelTests.swift
@@ -98,7 +98,12 @@ struct ProfileViewModelTests {
         viewModel.showProfilePhotoUpdatedToast()
         #expect(viewModel.profilePhotoToastMessage == "프로필 사진이 변경되었어요.")
 
-        try? await Task.sleep(for: .milliseconds(120))
+        for _ in 0..<40 {
+            if viewModel.profilePhotoToastMessage == nil {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
 
         #expect(viewModel.profilePhotoToastMessage == nil)
     }

--- a/NailClient/NailClientTests/TestSupport/Helpers/ImagePrefetchRecorder.swift
+++ b/NailClient/NailClientTests/TestSupport/Helpers/ImagePrefetchRecorder.swift
@@ -1,0 +1,32 @@
+import CoreGraphics
+import Foundation
+@testable import NailClient
+
+@MainActor
+final class ImagePrefetchRecorder {
+    struct Call {
+        let urls: [URL]
+        let targetSize: CGSize?
+        let resizeMode: NailImageResizeMode
+        let destination: NailImagePrefetchDestination
+    }
+
+    private(set) var calls: [Call] = []
+
+    var prefetch: NailImagePrefetchClosure {
+        { [weak self] urls, targetSize, resizeMode, destination in
+            self?.calls.append(
+                Call(
+                    urls: urls,
+                    targetSize: targetSize,
+                    resizeMode: resizeMode,
+                    destination: destination
+                )
+            )
+        }
+    }
+
+    func reset() {
+        calls.removeAll()
+    }
+}

--- a/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
@@ -26,12 +26,19 @@ enum MockDeleteMyAccountBehavior {
     case failure(Error)
 }
 
+enum MockCompletedNailGenerationListBehavior {
+    case unsupported
+    case success(response: NailGenListResponse, session: AppSession)
+    case failure(Error)
+}
+
 actor MockAuthService: AuthServicing {
     let behavior: MockAutoLoginBehavior
     let signInWithGoogleResult: Result<AuthResult, Error>?
     let signInWithAppleResult: Result<AuthResult, Error>?
     let updateMyProfileBehavior: MockUpdateMyProfileBehavior
     let deleteMyAccountBehavior: MockDeleteMyAccountBehavior
+    let completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior
     private(set) var clearLocalSessionCallCount: Int = 0
     private(set) var upsertPushTokenCallCount: Int = 0
 
@@ -40,13 +47,15 @@ actor MockAuthService: AuthServicing {
         signInWithGoogleResult: Result<AuthResult, Error>? = nil,
         signInWithAppleResult: Result<AuthResult, Error>? = nil,
         updateMyProfileBehavior: MockUpdateMyProfileBehavior = .unsupported,
-        deleteMyAccountBehavior: MockDeleteMyAccountBehavior = .unsupported
+        deleteMyAccountBehavior: MockDeleteMyAccountBehavior = .unsupported,
+        completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior = .unsupported
     ) {
         self.behavior = behavior
         self.signInWithGoogleResult = signInWithGoogleResult
         self.signInWithAppleResult = signInWithAppleResult
         self.updateMyProfileBehavior = updateMyProfileBehavior
         self.deleteMyAccountBehavior = deleteMyAccountBehavior
+        self.completedNailGenerationListBehavior = completedNailGenerationListBehavior
     }
 
     func tryAutoLogin(traceId: String, timeout: Duration) async throws -> AuthResult? {
@@ -189,6 +198,28 @@ actor MockAuthService: AuthServicing {
         _ = session
         _ = jobId
         throw MockAuthError.unsupported
+    }
+
+    func fetchCompletedNailGenerationList(
+        traceId: String,
+        session: AppSession,
+        limit: Int,
+        cursor: String?,
+        likedOnly: Bool
+    ) async throws -> (response: NailGenListResponse, session: AppSession) {
+        _ = traceId
+        _ = session
+        _ = limit
+        _ = cursor
+        _ = likedOnly
+        switch completedNailGenerationListBehavior {
+        case .unsupported:
+            throw MockAuthError.unsupported
+        case let .success(response, session):
+            return (response, session)
+        case let .failure(error):
+            throw error
+        }
     }
 
     func deleteMyAccount(


### PR DESCRIPTION
## Summary
- AI 피팅 결과 그리드의 썸네일 요청 크기를 실측 타일 크기 기반으로 정리했습니다.
- 앱 첫 진입 preload는 디스크 캐시용 raw thumbnail bytes만 채우고, 결과 화면은 메모리 우선 prefetch를 담당하도록 역할을 분리했습니다.
- prefetch recorder와 레이아웃/뷰모델/AppViewModel 테스트를 추가해 로딩 경로를 검증했습니다.

## Scope
- In scope: 결과 그리드 타일 크기 계산, thumbnail prefetch destination 분리, AppViewModel 첫 페이지 thumbnail preload, 관련 테스트 보강
- Out of scope: AI 생성 파이프라인 속도, backend/shared-schema 변경, 결과 상세 시트 인접 이미지 prefetch 변경

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bash scripts/ios-warning-gate.sh`

## Risk & Rollback
- 위험 지점은 thumbnail prefetch 타이밍과 target size 계산입니다.
- 이상이 있으면 이 PR의 squash commit을 revert하면 기존 고정 180 썸네일 요청과 단순 prefetch 경로로 되돌릴 수 있습니다.

## Closes
- Closes #33
