### PR TITLE
refactor(results-tab): 목록 모델 분리와 첫 페이지 18개 전환

### DIFF
--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -197,7 +197,6 @@ final class AppViewModel: ObservableObject {
         aiGenerationIsRunning = false
         aiGenerationProgressMessage = "생성이 완료되었습니다."
         activeAIGenerationJobId = nil
-        refreshNailGenerationFirstPageCache(likedOnly: false)
     }
 
     func failAIGeneration(jobId: UUID?, message: String) {
@@ -302,9 +301,6 @@ final class AppViewModel: ObservableObject {
         onboardingPrefill = nextPrefill
         await syncPushTokenRegistrationIfPossible()
         route = nextRoute
-        if nextRoute == .home {
-            await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
-        }
         launchPhase = .ready
         flushPendingPushRouteIfPossible()
 
@@ -328,9 +324,6 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
-            if route == .home {
-                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
-            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithKakao failed: \(String(describing: error), privacy: .public)")
@@ -355,9 +348,6 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
-            if route == .home {
-                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
-            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithGoogle failed: \(String(describing: error), privacy: .public)")
@@ -382,9 +372,6 @@ final class AppViewModel: ObservableObject {
             }
             await syncPushTokenRegistrationIfPossible()
             route = result.needsOnboarding ? .onboarding : .home
-            if route == .home {
-                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
-            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithApple failed: \(String(describing: error), privacy: .public)")
@@ -457,9 +444,6 @@ final class AppViewModel: ObservableObject {
             currentUser = updated.user
             onboardingPrefill = updated.needsOnboarding ? prefillFromUser(updated.user) : nil
             route = updated.needsOnboarding ? .onboarding : .home
-            if route == .home {
-                await preloadNailGenerationFirstPage(limit: 20, likedOnly: false)
-            }
             flushPendingPushRouteIfPossible()
         } catch {
             AppLog.api.error("\(AppLog.prefix(traceId, "API")) completeOnboarding failed: \(String(describing: error), privacy: .public)")
@@ -684,14 +668,9 @@ final class AppViewModel: ObservableObject {
         limit: Int,
         likedOnly: Bool
     ) -> NailGenListResponse? {
-        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
-        guard let entry = nailGenListFirstPageCache[key] else { return nil }
-        let age = Date().timeIntervalSince(entry.cachedAt)
-        guard age <= nailGenListCacheTTL else {
-            nailGenListFirstPageCache[key] = nil
-            return nil
-        }
-        return entry.response
+        _ = limit
+        _ = likedOnly
+        return nil
     }
 
     func setCachedNailGenerationFirstPage(
@@ -699,35 +678,26 @@ final class AppViewModel: ObservableObject {
         limit: Int,
         likedOnly: Bool
     ) {
-        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
-        nailGenListFirstPageCache[key] = NailGenListCacheEntry(
-            response: response,
-            cachedAt: Date()
-        )
+        _ = response
+        _ = limit
+        _ = likedOnly
     }
 
     func preloadNailGenerationFirstPage(
         limit: Int,
         likedOnly: Bool
     ) async {
-        let key = NailGenListCacheKey(limit: limit, likedOnly: likedOnly)
-        if cachedNailGenerationFirstPage(limit: limit, likedOnly: likedOnly) != nil {
-            return
-        }
+        _ = limit
+        _ = likedOnly
+    }
 
-        if let existingTask = nailGenListFirstPagePreloadTasks[key] {
-            await existingTask.value
-            return
-        }
-
-        guard session != nil else { return }
-
-        let task = Task<Void, Never> { [weak self] in
-            guard let self else { return }
-            await self.runNailGenListFirstPagePreload(key: key)
-        }
-        nailGenListFirstPagePreloadTasks[key] = task
-        await task.value
+    func prepareNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async -> NailGenListResponse? {
+        _ = limit
+        _ = likedOnly
+        return nil
     }
 
     func invalidateNailGenerationFirstPageCache(likedOnly: Bool? = nil) {
@@ -753,15 +723,9 @@ final class AppViewModel: ObservableObject {
         likedOnly: Bool,
         limit: Int = 20
     ) {
-        invalidateNailGenerationFirstPageCache(likedOnly: likedOnly)
-        guard session != nil else { return }
-
-        Task { [weak self] in
-            await self?.preloadNailGenerationFirstPage(
-                limit: limit,
-                likedOnly: likedOnly
-            )
-        }
+        _ = likedOnly
+        _ = limit
+        invalidateNailGenerationFirstPageCache()
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {
@@ -887,6 +851,9 @@ final class AppViewModel: ObservableObject {
                     .uniqued()
                     .prefix(12)
             )
+            let missingThumbnailCount = response.items.filter { item in
+                Self.thumbnailPrefetchURL(from: item) == nil
+            }.count
             imagePrefetch(
                 prefetchURLs,
                 nil,
@@ -895,7 +862,7 @@ final class AppViewModel: ObservableObject {
             )
             let traceId = AppLog.makeErrorId()
             AppLog.api.debug(
-                "\(AppLog.prefix(traceId, "API")) nail-gen-list preload_success likedOnly=\(key.likedOnly, privacy: .public) limit=\(key.limit, privacy: .public)"
+                "\(AppLog.prefix(traceId, "API")) nail-gen-list preload_success likedOnly=\(key.likedOnly, privacy: .public) limit=\(key.limit, privacy: .public) prefetch_count=\(prefetchURLs.count, privacy: .public) missing_thumbnail_count=\(missingThumbnailCount, privacy: .public)"
             )
         } catch {
             let traceId = AppLog.makeErrorId()
@@ -1101,13 +1068,6 @@ final class AppViewModel: ObservableObject {
            let url = URL(string: rawThumbnailURL) {
             return url
         }
-
-        if let rawResultURL = item.resultImageURL?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !rawResultURL.isEmpty,
-           let url = URL(string: rawResultURL) {
-            return url
-        }
-
         return nil
     }
 }

--- a/NailClient/NailClient/Features/AIGeneration/ViewModels/AINailGenerationViewModel.swift
+++ b/NailClient/NailClient/Features/AIGeneration/ViewModels/AINailGenerationViewModel.swift
@@ -565,13 +565,13 @@ final class AINailGenerationViewModel: ObservableObject {
 
     func makeAutoOpenedDetailItem(
         createdAt: Date = Date()
-    ) -> FittedAIImagesViewModel.FittedAIImageItem? {
+    ) -> FittedAIImagesViewModel.FittedAIImageDetailItem? {
         guard let currentJobId, let resultImageURL else { return nil }
 
-        return FittedAIImagesViewModel.FittedAIImageItem(
+        return FittedAIImagesViewModel.FittedAIImageDetailItem(
             jobId: currentJobId,
             thumbnailURL: nil,
-            fullImageURL: resultImageURL,
+            generatedImageURL: resultImageURL,
             shape: selectedShape.apiValue,
             extensionMode: selectedExtensionOption.apiValue,
             createdAt: createdAt,

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -15,7 +15,7 @@ struct AINailGenerationView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @StateObject private var viewModel: AINailGenerationViewModel
-    @State private var selectedDetailItem: FittedAIImagesViewModel.FittedAIImageItem?
+    @State private var selectedDetailItem: FittedAIImagesViewModel.FittedAIImageDetailItem?
     @State private var isHandPhotoPickerPresented: Bool = false
     @State private var isDesignPhotoPickerPresented: Bool = false
     @State private var isHandPhotoSourceDialogPresented: Bool = false
@@ -873,7 +873,6 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == response.jobId {
                 selectedDetailItem?.isLiked = response.isLiked
             }
-            refreshResultListCaches(includeLiked: true)
             return true
         } catch {
             return false
@@ -886,17 +885,9 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == jobId {
                 selectedDetailItem = nil
             }
-            refreshResultListCaches(includeLiked: true)
             return true
         } catch {
             return false
-        }
-    }
-
-    private func refreshResultListCaches(includeLiked: Bool) {
-        appViewModel.refreshNailGenerationFirstPageCache(likedOnly: false)
-        if includeLiked {
-            appViewModel.refreshNailGenerationFirstPageCache(likedOnly: true)
         }
     }
 

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -32,6 +32,10 @@ protocol FittedAIImagesServicing: AnyObject {
         limit: Int,
         likedOnly: Bool
     ) async
+    func prepareNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async -> NailGenListResponse?
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse
     func deleteNailGeneration(jobId: UUID) async throws -> NailGenDeleteResponse
 }
@@ -74,6 +78,15 @@ extension FittedAIImagesServicing {
         _ = limit
         _ = likedOnly
     }
+
+    func prepareNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async -> NailGenListResponse? {
+        _ = limit
+        _ = likedOnly
+        return nil
+    }
 }
 
 @MainActor
@@ -81,6 +94,27 @@ final class FittedAIImagesViewModel: ObservableObject {
     private enum LoadFailureHandling {
         case standard
         case restoreOnCancellation
+    }
+
+    private enum FetchApplicationMode {
+        case replace
+        case append
+        case mergeFirstPage
+
+        var logSource: String {
+            switch self {
+            case .replace:
+                return "replace"
+            case .append:
+                return "append"
+            case .mergeFirstPage:
+                return "merge"
+            }
+        }
+    }
+
+    private enum FirstPageReadySource: String {
+        case network
     }
 
     private struct ThumbnailPrefetchKey: Hashable {
@@ -93,6 +127,7 @@ final class FittedAIImagesViewModel: ObservableObject {
     private struct FetchPageResult {
         let response: NailGenListResponse
         let items: [FittedAIImageItem]
+        let detailItemsByID: [UUID: FittedAIImageDetailItem]
         let nextCursor: String?
     }
 
@@ -142,7 +177,29 @@ final class FittedAIImagesViewModel: ObservableObject {
     struct FittedAIImageItem: Identifiable, Equatable {
         let jobId: UUID
         let thumbnailURL: URL?
-        let fullImageURL: URL?
+        let createdAt: Date
+        var isLiked: Bool
+
+        var id: UUID { jobId }
+        var imageURL: URL? { thumbnailURL }
+        var thumbnailSourceForLog: String {
+            guard let thumbnailURL else { return "missing" }
+            let raw = thumbnailURL.absoluteString
+            if raw.contains("/storage/v1/object/public/nail-results-thumb-public/") {
+                return "stored"
+            }
+            return "fallback"
+        }
+
+        var shortJobID: String {
+            String(jobId.uuidString.prefix(8))
+        }
+    }
+
+    struct FittedAIImageDetailItem: Identifiable, Equatable {
+        let jobId: UUID
+        let thumbnailURL: URL?
+        let generatedImageURL: URL?
         let shape: NailGenShape?
         let extensionMode: NailGenExtensionMode?
         let createdAt: Date
@@ -151,15 +208,10 @@ final class FittedAIImagesViewModel: ObservableObject {
         var isLiked: Bool
 
         var id: UUID { jobId }
-        var imageURL: URL? { thumbnailURL ?? fullImageURL }
-        var generatedImageURLForDetail: URL? { fullImageURL ?? thumbnailURL }
+        var generatedImageURLForDetail: URL? { generatedImageURL ?? thumbnailURL }
 
         var isRefined: Bool {
             refinementTurn > 0 || parentJobId != nil
-        }
-
-        var shortJobID: String {
-            String(jobId.uuidString.prefix(8))
         }
     }
 
@@ -187,9 +239,20 @@ final class FittedAIImagesViewModel: ObservableObject {
     private var inFlightPageFetchTasks: [PageFetchKey: Task<FetchPageResult, Error>] = [:]
     private var thumbnailTargetSize: CGSize?
     private var thumbnailPrefetchKeys: Set<ThumbnailPrefetchKey> = []
+    private var allItemIndexByID: [UUID: Int] = [:]
+    private var likedItemIndexByID: [UUID: Int] = [:]
+    private var detailItemsByID: [UUID: FittedAIImageDetailItem] = [:]
+    private var allLastPrefetchAnchor: Int?
+    private var likedLastPrefetchAnchor: Int?
+    private var resultsTabEnteredAt: Date?
+    private var didLogFirstThumbnailDisplay: Bool = false
+    private var didLogFirstScreenPrefetch: Bool = false
+    private var isLoadMoreArmed: Bool = false
+    private var didLogLoadMoreArmed: Bool = false
+    private var didLogInitialLoadMoreBlocked: Bool = false
 
     init(
-        pageSize: Int = 20,
+        pageSize: Int = 18,
         imagePrefetch: @escaping NailImagePrefetchClosure = NailImagePipeline.prefetch
     ) {
         self.pageSize = max(1, min(pageSize, 50))
@@ -243,10 +306,65 @@ final class FittedAIImagesViewModel: ObservableObject {
     func updateThumbnailTargetSize(_ targetSize: CGSize) {
         let normalized = Self.normalizedThumbnailTargetSize(targetSize)
         guard let normalized else { return }
-        guard thumbnailTargetSize != normalized else { return }
+        let didChangeTargetSize = thumbnailTargetSize != normalized
+        guard didChangeTargetSize else { return }
+
         thumbnailTargetSize = normalized
-        thumbnailPrefetchKeys.removeAll()
+        if didChangeTargetSize {
+            thumbnailPrefetchKeys.removeAll()
+            allLastPrefetchAnchor = nil
+            likedLastPrefetchAnchor = nil
+        }
         prefetchLeadingThumbnails(for: selectedFilter)
+    }
+
+    func updateScrollOffset(_ offsetY: CGFloat) {
+        guard !isLoadMoreArmed else { return }
+        guard let targetSize = thumbnailTargetSize else { return }
+
+        let threshold = targetSize.height + 1
+        guard offsetY >= threshold else { return }
+
+        isLoadMoreArmed = true
+        guard !didLogLoadMoreArmed else { return }
+        didLogLoadMoreArmed = true
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_load_more_armed offset=\(Int(offsetY.rounded()), privacy: .public)"
+        )
+    }
+
+    func recordScreenEntered() {
+        resultsTabEnteredAt = Date()
+        didLogFirstThumbnailDisplay = false
+        didLogFirstScreenPrefetch = false
+        resetLoadMoreArming()
+        clearThumbnailPrefetchKeys(destination: .memoryCache)
+        setLastPrefetchAnchor(nil, for: selectedFilter)
+
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_entered filter=\(self.selectedFilter.rawValue, privacy: .public) items=\(self.items.count, privacy: .public)"
+        )
+
+        prefetchLeadingThumbnails(for: selectedFilter)
+    }
+
+    func recordThumbnailDisplayed(jobId: UUID, source: String) {
+        guard !didLogFirstThumbnailDisplay else { return }
+        didLogFirstThumbnailDisplay = true
+
+        let elapsedMilliseconds: Int
+        if let referenceAt = resultsTabEnteredAt {
+            elapsedMilliseconds = max(Int(Date().timeIntervalSince(referenceAt) * 1_000), 0)
+        } else {
+            elapsedMilliseconds = -1
+        }
+
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_first_thumbnail_displayed job=\(String(jobId.uuidString.prefix(8)), privacy: .public) elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
+        )
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_first_thumbnail_source job=\(String(jobId.uuidString.prefix(8)), privacy: .public) source=\(source, privacy: .public)"
+        )
     }
 
     func loadIfNeeded() async {
@@ -257,6 +375,7 @@ final class FittedAIImagesViewModel: ObservableObject {
     func setFilter(_ filter: ListFilter) async {
         guard selectedFilter != filter else { return }
         selectedFilter = filter
+        resetLoadMoreArming()
 
         if !didLoad(filter: filter) {
             await loadInitial(for: filter, force: false)
@@ -269,12 +388,28 @@ final class FittedAIImagesViewModel: ObservableObject {
         await loadInitial(
             for: selectedFilter,
             force: true,
-            failureHandling: .restoreOnCancellation
+            failureHandling: .restoreOnCancellation,
+            mergeOnForce: true
         )
     }
 
     func retry() async {
-        await loadInitial(for: selectedFilter, force: true)
+        await loadInitial(for: selectedFilter, force: true, mergeOnForce: false)
+    }
+
+    func shouldTriggerLoadMore(currentItemID: UUID) -> Bool {
+        guard nextCursor(for: selectedFilter) != nil else { return false }
+        guard loadMoreTriggerItemID(for: selectedFilter) == currentItemID else { return false }
+        guard isLoadMoreArmed else {
+            if !didLogInitialLoadMoreBlocked {
+                didLogInitialLoadMoreBlocked = true
+                AppLog.ui.info(
+                    "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_load_more_blocked reason=initial_viewport"
+                )
+            }
+            return false
+        }
+        return true
     }
 
     func loadMoreIfNeeded(currentItemID: UUID) async {
@@ -282,20 +417,18 @@ final class FittedAIImagesViewModel: ObservableObject {
         guard !isLoading(for: filter), !isLoadingMore(for: filter) else { return }
         guard let nextCursor = nextCursor(for: filter) else { return }
         let requestGeneration = loadGeneration(for: filter)
-
-        let currentItems = items(for: filter)
-        guard let index = currentItems.firstIndex(where: { $0.id == currentItemID }) else { return }
-
-        let thresholdIndex = max(currentItems.count - 6, 0)
-        guard index >= thresholdIndex else { return }
+        guard loadMoreTriggerItemID(for: filter) == currentItemID else { return }
 
         setLoadingMore(true, for: filter)
         defer { setLoadingMore(false, for: filter) }
 
         do {
+            AppLog.ui.info(
+                "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_load_more_started current_count=\(self.items(for: filter).count, privacy: .public) cursor_present=true"
+            )
             let result = try await fetchPage(filter: filter, cursor: nextCursor)
             guard requestGeneration == loadGeneration(for: filter) else { return }
-            applyFetchResult(result, for: filter, replaceItems: false)
+            applyFetchResult(result, for: filter, mode: .append)
             setError(nil, for: filter)
             setDidLoad(true, for: filter)
         } catch {
@@ -308,8 +441,13 @@ final class FittedAIImagesViewModel: ObservableObject {
 
     func prefetchNearFutureThumbnails(currentItemID: UUID) {
         guard let targetSize = thumbnailTargetSize else { return }
-        let currentItems = items(for: selectedFilter)
-        guard let index = currentItems.firstIndex(where: { $0.id == currentItemID }) else { return }
+        let filter = selectedFilter
+        let currentItems = items(for: filter)
+        guard let index = itemIndexByID(for: filter)[currentItemID] else { return }
+
+        let nextAnchor = index / 3
+        guard lastPrefetchAnchor(for: filter) != nextAnchor else { return }
+        setLastPrefetchAnchor(nextAnchor, for: filter)
 
         let nextItems = currentItems.dropFirst(index + 1).prefix(Self.nearFutureThumbnailPrefetchCount)
         prefetchThumbnailItems(Array(nextItems), targetSize: targetSize, destination: .memoryCache)
@@ -345,6 +483,10 @@ final class FittedAIImagesViewModel: ObservableObject {
         )
     }
 
+    func detailItem(for jobId: UUID) -> FittedAIImageDetailItem? {
+        detailItemsByID[jobId]
+    }
+
     func delete(jobId: UUID) async -> Bool {
         guard let service else { return false }
         guard deletingJobIDs.contains(jobId) == false else { return false }
@@ -359,6 +501,7 @@ final class FittedAIImagesViewModel: ObservableObject {
 
             allItems.removeAll { targetIDs.contains($0.jobId) }
             likedItems.removeAll { targetIDs.contains($0.jobId) }
+            detailItemsByID = detailItemsByID.filter { !targetIDs.contains($0.key) }
 
             setError(nil, for: selectedFilter)
             return true
@@ -384,6 +527,7 @@ final class FittedAIImagesViewModel: ObservableObject {
 
         let previousAllItems = allItems
         let previousLikedItems = likedItems
+        let previousDetailItem = detailItemsByID[jobId]
 
         likingJobIDs.insert(jobId)
         applyLikeState(jobId: jobId, isLiked: isLiked)
@@ -398,6 +542,9 @@ final class FittedAIImagesViewModel: ObservableObject {
         } catch {
             allItems = previousAllItems
             likedItems = previousLikedItems
+            if let previousDetailItem {
+                detailItemsByID[jobId] = previousDetailItem
+            }
             setError("좋아요 상태 변경에 실패했어요. 잠시 후 다시 시도해 주세요.", for: selectedFilter)
             return false
         }
@@ -449,12 +596,13 @@ final class FittedAIImagesViewModel: ObservableObject {
     private func loadInitial(
         for filter: ListFilter,
         force: Bool,
-        failureHandling: LoadFailureHandling = .standard
+        failureHandling: LoadFailureHandling = .standard,
+        mergeOnForce: Bool = false
     ) async {
         guard !isLoading(for: filter) else { return }
         if !force, isLoadingMore(for: filter) { return }
         if didLoad(filter: filter) && !force { return }
-        guard let service else { return }
+        guard service != nil else { return }
         let requestGeneration = force ? bumpLoadGeneration(for: filter) : loadGeneration(for: filter)
 
         let snapshot: ListStateSnapshot?
@@ -464,56 +612,31 @@ final class FittedAIImagesViewModel: ObservableObject {
             snapshot = nil
         }
 
-        let cachedFirstPage: FetchPageResult?
-        if !force,
-           let cached = service.cachedNailGenerationFirstPage(limit: pageSize, likedOnly: filter.likedOnly) {
-            cachedFirstPage = FetchPageResult(
-                response: cached,
-                items: cached.items.map(Self.makeItem),
-                nextCursor: cached.nextCursor
-            )
-        } else {
-            cachedFirstPage = nil
-        }
-
-        if let cachedFirstPage {
-            applyFetchResult(cachedFirstPage, for: filter, replaceItems: true)
-            setError(nil, for: filter)
-            setDidLoad(true, for: filter)
-        }
-
-        let shouldShowLoading = cachedFirstPage == nil
-        if shouldShowLoading {
-            setLoading(true, for: filter)
-        }
-        defer {
-            if shouldShowLoading {
-                setLoading(false, for: filter)
-            }
-        }
+        setLoading(true, for: filter)
+        defer { setLoading(false, for: filter) }
 
         if force {
             setNextCursor(nil, for: filter)
-        }
-        if force {
-            setItems([], for: filter)
         }
 
         do {
             let result = try await fetchPage(filter: filter, cursor: nil)
             guard requestGeneration == loadGeneration(for: filter) else { return }
-            applyFetchResult(result, for: filter, replaceItems: true)
-            service.setCachedNailGenerationFirstPage(
-                result.response,
-                limit: pageSize,
-                likedOnly: filter.likedOnly
+            let applicationMode = refreshApplicationMode(
+                for: filter,
+                force: force,
+                mergeOnForce: mergeOnForce
             )
+            applyFetchResult(result, for: filter, mode: applicationMode)
+            if !force {
+                logFirstPageReady(source: .network, filter: filter, count: result.items.count)
+            }
             setError(nil, for: filter)
             setDidLoad(true, for: filter)
             if force {
                 let traceId = AppLog.makeErrorId()
                 AppLog.api.info(
-                    "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(result.items.count, privacy: .public)"
+                    "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(result.items.count, privacy: .public) mode=\(applicationMode.logSource, privacy: .public)"
                 )
             }
         } catch {
@@ -524,17 +647,17 @@ final class FittedAIImagesViewModel: ObservableObject {
                 do {
                     let retriedResult = try await fetchPage(filter: filter, cursor: nil)
                     guard requestGeneration == loadGeneration(for: filter) else { return }
-                    applyFetchResult(retriedResult, for: filter, replaceItems: true)
-                    service.setCachedNailGenerationFirstPage(
-                        retriedResult.response,
-                        limit: pageSize,
-                        likedOnly: filter.likedOnly
+                    let applicationMode = refreshApplicationMode(
+                        for: filter,
+                        force: force,
+                        mergeOnForce: mergeOnForce
                     )
+                    applyFetchResult(retriedResult, for: filter, mode: applicationMode)
                     setError(nil, for: filter)
                     setDidLoad(true, for: filter)
                     let traceId = AppLog.makeErrorId()
                     AppLog.api.info(
-                        "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(retriedResult.items.count, privacy: .public) attempt=retry_after_cancel"
+                        "\(AppLog.prefix(traceId, "API")) refresh_success filter=\(filter.rawValue, privacy: .public) items=\(retriedResult.items.count, privacy: .public) mode=\(applicationMode.logSource, privacy: .public) attempt=retry_after_cancel"
                     )
                     return
                 } catch {
@@ -549,12 +672,6 @@ final class FittedAIImagesViewModel: ObservableObject {
                     setDidLoad(true, for: filter)
                     return
                 }
-            }
-
-            if cachedFirstPage != nil && !force {
-                setError(nil, for: filter)
-                setDidLoad(true, for: filter)
-                return
             }
 
             if failureHandling == .restoreOnCancellation,
@@ -592,10 +709,12 @@ final class FittedAIImagesViewModel: ObservableObject {
                 cursor: cursor,
                 likedOnly: filter.likedOnly
             )
+            let detailItems = response.items.map(Self.makeDetailItem)
 
             return FetchPageResult(
                 response: response,
                 items: response.items.map(Self.makeItem),
+                detailItemsByID: Dictionary(uniqueKeysWithValues: detailItems.map { ($0.jobId, $0) }),
                 nextCursor: response.nextCursor
             )
         }
@@ -608,24 +727,35 @@ final class FittedAIImagesViewModel: ObservableObject {
     private func applyFetchResult(
         _ result: FetchPageResult,
         for filter: ListFilter,
-        replaceItems: Bool
+        mode: FetchApplicationMode
     ) {
+        registerDetailItems(result.detailItemsByID)
+        logThumbnailAvailability(result.items, for: filter, source: mode.logSource)
         let previousItems = items(for: filter)
         let appendedItems: [FittedAIImageItem]
-        if replaceItems {
+        switch mode {
+        case .replace:
             setItems(result.items, for: filter)
             appendedItems = result.items
-        } else {
+        case .append:
             let existing = Set(previousItems.map(\.jobId))
             let newItems = result.items.filter { !existing.contains($0.jobId) }
             let appended = previousItems + newItems
             setItems(appended, for: filter)
             appendedItems = newItems
+        case .mergeFirstPage:
+            let mergedItems = mergeFirstPageItems(
+                existing: previousItems,
+                fetchedFirstPage: result.items
+            )
+            setItems(mergedItems, for: filter)
+            appendedItems = []
         }
 
-        if replaceItems {
+        switch mode {
+        case .replace, .mergeFirstPage:
             prefetchLeadingThumbnails(for: filter)
-        } else {
+        case .append:
             prefetchAppendedThumbnails(appendedItems)
         }
         setNextCursor(result.nextCursor, for: filter)
@@ -634,22 +764,28 @@ final class FittedAIImagesViewModel: ObservableObject {
     private func prefetchLeadingThumbnails(for filter: ListFilter) {
         guard let targetSize = thumbnailTargetSize else { return }
         let leadingItems = Array(items(for: filter).prefix(Self.leadingThumbnailPrefetchCount))
-        prefetchThumbnailItems(leadingItems, targetSize: targetSize, destination: .memoryCache)
+        let queuedCount = prefetchThumbnailItems(leadingItems, targetSize: targetSize, destination: .memoryCache)
+        guard queuedCount > 0, !didLogFirstScreenPrefetch else { return }
+        didLogFirstScreenPrefetch = true
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_first_screen_prefetch_queued filter=\(filter.rawValue, privacy: .public) count=\(queuedCount, privacy: .public)"
+        )
     }
 
     private func prefetchAppendedThumbnails(_ appendedItems: [FittedAIImageItem]) {
         guard let targetSize = thumbnailTargetSize else { return }
         let prioritizedItems = Array(appendedItems.prefix(Self.appendedThumbnailPrefetchCount))
-        prefetchThumbnailItems(prioritizedItems, targetSize: targetSize, destination: .memoryCache)
+        _ = prefetchThumbnailItems(prioritizedItems, targetSize: targetSize, destination: .memoryCache)
     }
 
+    @discardableResult
     private func prefetchThumbnailItems(
         _ items: [FittedAIImageItem],
         targetSize: CGSize,
         destination: NailImagePrefetchDestination
-    ) {
+    ) -> Int {
         let normalizedSize = Self.normalizedThumbnailTargetSize(targetSize)
-        guard let normalizedSize else { return }
+        guard let normalizedSize else { return 0 }
 
         var urlsToPrefetch: [URL] = []
         for url in items.compactMap(\.imageURL) {
@@ -664,13 +800,14 @@ final class FittedAIImagesViewModel: ObservableObject {
             urlsToPrefetch.append(url)
         }
 
-        guard !urlsToPrefetch.isEmpty else { return }
+        guard !urlsToPrefetch.isEmpty else { return 0 }
         imagePrefetch(
             urlsToPrefetch,
             normalizedSize,
             .fill,
             destination
         )
+        return urlsToPrefetch.count
     }
 
     private static func normalizedThumbnailTargetSize(_ targetSize: CGSize?) -> CGSize? {
@@ -716,9 +853,65 @@ final class FittedAIImagesViewModel: ObservableObject {
             ?? likedItems.first(where: { $0.jobId == jobId })
     }
 
+    private func loadMoreTriggerItemID(for filter: ListFilter) -> UUID? {
+        let currentItems = items(for: filter)
+        guard !currentItems.isEmpty else { return nil }
+        let thresholdIndex = max(currentItems.count - 6, 0)
+        guard currentItems.indices.contains(thresholdIndex) else { return nil }
+        return currentItems[thresholdIndex].id
+    }
+
+    private func refreshApplicationMode(
+        for filter: ListFilter,
+        force: Bool,
+        mergeOnForce: Bool
+    ) -> FetchApplicationMode {
+        guard force, mergeOnForce, filter == .all, !items(for: filter).isEmpty else { return .replace }
+        return .mergeFirstPage
+    }
+
+    private func clearThumbnailPrefetchKeys(destination: NailImagePrefetchDestination) {
+        thumbnailPrefetchKeys = thumbnailPrefetchKeys.filter { $0.destination != destination }
+    }
+
+    private func resetLoadMoreArming() {
+        isLoadMoreArmed = false
+        didLogLoadMoreArmed = false
+        didLogInitialLoadMoreBlocked = false
+    }
+
+    private func logThumbnailAvailability(
+        _ items: [FittedAIImageItem],
+        for filter: ListFilter,
+        source: String
+    ) {
+        guard !items.isEmpty else { return }
+        let missingCount = items.filter { $0.thumbnailURL == nil }.count
+        guard missingCount > 0 else { return }
+
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_missing_thumbnails filter=\(filter.rawValue, privacy: .public) source=\(source, privacy: .public) missing=\(missingCount, privacy: .public) total=\(items.count, privacy: .public)"
+        )
+    }
+
+    private func logFirstPageReady(
+        source: FirstPageReadySource,
+        filter: ListFilter,
+        count: Int
+    ) {
+        AppLog.ui.info(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_tab_first_page_ready filter=\(filter.rawValue, privacy: .public) source=\(source.rawValue, privacy: .public) items=\(count, privacy: .public)"
+        )
+    }
+
     private func applyLikeState(jobId: UUID, isLiked: Bool) {
         if let index = allItems.firstIndex(where: { $0.jobId == jobId }) {
             allItems[index].isLiked = isLiked
+        }
+
+        if var detailItem = detailItemsByID[jobId] {
+            detailItem.isLiked = isLiked
+            detailItemsByID[jobId] = detailItem
         }
 
         if isLiked {
@@ -741,6 +934,41 @@ final class FittedAIImagesViewModel: ObservableObject {
         return lhs.jobId.uuidString > rhs.jobId.uuidString
     }
 
+    private func mergeFirstPageItems(
+        existing: [FittedAIImageItem],
+        fetchedFirstPage: [FittedAIImageItem]
+    ) -> [FittedAIImageItem] {
+        guard !existing.isEmpty else { return fetchedFirstPage }
+        guard !fetchedFirstPage.isEmpty else { return [] }
+
+        let fetchedIDs = Set(fetchedFirstPage.map(\.jobId))
+        let lastOverlapIndex = existing.lastIndex { item in
+            fetchedIDs.contains(item.jobId)
+        }
+
+        let tail: [FittedAIImageItem]
+        if let lastOverlapIndex {
+            tail = Array(existing.dropFirst(lastOverlapIndex + 1))
+        } else {
+            tail = existing.filter { !fetchedIDs.contains($0.jobId) }
+        }
+
+        var merged: [FittedAIImageItem] = []
+        var seenIDs: Set<UUID> = []
+        for item in fetchedFirstPage + tail {
+            guard seenIDs.insert(item.jobId).inserted else { continue }
+            merged.append(item)
+        }
+        return merged
+    }
+
+    private func registerDetailItems(_ fetchedDetailItemsByID: [UUID: FittedAIImageDetailItem]) {
+        guard !fetchedDetailItemsByID.isEmpty else { return }
+        for (jobId, detailItem) in fetchedDetailItemsByID {
+            detailItemsByID[jobId] = detailItem
+        }
+    }
+
     private func items(for filter: ListFilter) -> [FittedAIImageItem] {
         switch filter {
         case .all:
@@ -754,8 +982,37 @@ final class FittedAIImagesViewModel: ObservableObject {
         switch filter {
         case .all:
             allItems = items
+            allItemIndexByID = Self.makeIndexMap(items)
         case .liked:
             likedItems = items
+            likedItemIndexByID = Self.makeIndexMap(items)
+        }
+    }
+
+    private func itemIndexByID(for filter: ListFilter) -> [UUID: Int] {
+        switch filter {
+        case .all:
+            return allItemIndexByID
+        case .liked:
+            return likedItemIndexByID
+        }
+    }
+
+    private func lastPrefetchAnchor(for filter: ListFilter) -> Int? {
+        switch filter {
+        case .all:
+            return allLastPrefetchAnchor
+        case .liked:
+            return likedLastPrefetchAnchor
+        }
+    }
+
+    private func setLastPrefetchAnchor(_ anchor: Int?, for filter: ListFilter) {
+        switch filter {
+        case .all:
+            allLastPrefetchAnchor = anchor
+        case .liked:
+            likedLastPrefetchAnchor = anchor
         }
     }
 
@@ -832,12 +1089,21 @@ final class FittedAIImagesViewModel: ObservableObject {
     }
 
     static func makeItem(_ item: NailGenListItemResponse) -> FittedAIImageItem {
-        let shape = parseShape(from: item.shape)
-
         return FittedAIImageItem(
             jobId: item.jobId,
             thumbnailURL: item.thumbnailImageURL.flatMap(URL.init(string:)),
-            fullImageURL: item.resultImageURL.flatMap(URL.init(string:)),
+            createdAt: item.createdAt,
+            isLiked: item.isLiked
+        )
+    }
+
+    static func makeDetailItem(_ item: NailGenListItemResponse) -> FittedAIImageDetailItem {
+        let shape = parseShape(from: item.shape)
+
+        return FittedAIImageDetailItem(
+            jobId: item.jobId,
+            thumbnailURL: item.thumbnailImageURL.flatMap(URL.init(string:)),
+            generatedImageURL: item.resultImageURL.flatMap(URL.init(string:)),
             shape: shape,
             extensionMode: item.extensionMode,
             createdAt: item.createdAt,
@@ -851,6 +1117,10 @@ final class FittedAIImagesViewModel: ObservableObject {
         guard let raw = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
               !raw.isEmpty else { return nil }
         return NailGenShape(rawValue: raw)
+    }
+
+    private static func makeIndexMap(_ items: [FittedAIImageItem]) -> [UUID: Int] {
+        Dictionary(uniqueKeysWithValues: items.enumerated().map { ($0.element.id, $0.offset) })
     }
 
 }
@@ -875,6 +1145,9 @@ extension FittedAIImagesViewModel {
         viewModel.selectedFilter = selectedFilter
         viewModel.allItems = resolvedAllItems
         viewModel.likedItems = resolvedLikedItems
+        viewModel.detailItemsByID = Dictionary(
+            uniqueKeysWithValues: resolvedAllItems.map { ($0.jobId, previewDetailItem(from: $0)) }
+        )
         viewModel.isLoadingAll = isLoadingAll
         viewModel.isLoadingLiked = isLoadingLiked
         viewModel.allErrorMessage = allErrorMessage
@@ -889,15 +1162,28 @@ extension FittedAIImagesViewModel {
             FittedAIImageItem(
                 jobId: UUID(uuidString: String(format: "00000000-0000-4000-8000-%012d", index + 1)) ?? UUID(),
                 thumbnailURL: PreviewFixtures.imageURL(name: "fit-thumb-\(index)", hue: CGFloat(index) * 0.08),
-                fullImageURL: PreviewFixtures.imageURL(name: "fit-full-\(index)", hue: CGFloat(index) * 0.08),
-                shape: index.isMultiple(of: 3) ? .almond : (index.isMultiple(of: 2) ? .square : .round),
-                extensionMode: index.isMultiple(of: 2) ? .natural : .extend,
                 createdAt: Date().addingTimeInterval(Double(-index) * 3_600),
-                parentJobId: index.isMultiple(of: 4) ? UUID(uuidString: "99999999-9999-4999-8999-999999999999") : nil,
-                refinementTurn: index.isMultiple(of: 4) ? 1 : 0,
                 isLiked: index.isMultiple(of: 3)
             )
         }
+    }
+
+    static func previewDetailItem(
+        from item: FittedAIImageItem,
+        shape: NailGenShape? = .almond,
+        extensionMode: NailGenExtensionMode? = .extend
+    ) -> FittedAIImageDetailItem {
+        FittedAIImageDetailItem(
+            jobId: item.jobId,
+            thumbnailURL: item.thumbnailURL,
+            generatedImageURL: PreviewFixtures.imageURL(name: "fit-full-\(item.shortJobID)", hue: 0.08),
+            shape: shape,
+            extensionMode: extensionMode,
+            createdAt: item.createdAt,
+            parentJobId: nil,
+            refinementTurn: 0,
+            isLiked: item.isLiked
+        )
     }
 }
 #endif

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -35,7 +35,7 @@ struct FittedAIImageDetailSheet: View {
     }
 
     @Environment(\.dismiss) private var dismiss
-    let item: FittedAIImagesViewModel.FittedAIImageItem
+    let item: FittedAIImagesViewModel.FittedAIImageDetailItem
     let onLoadDetailImages: @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailImageSet
     let onToggleLike: @MainActor (Bool) async -> Bool
     let onDelete: @MainActor () async -> Bool
@@ -56,7 +56,7 @@ struct FittedAIImageDetailSheet: View {
     @State private var isScrollEnabled: Bool = false
 
     init(
-        item: FittedAIImagesViewModel.FittedAIImageItem,
+        item: FittedAIImagesViewModel.FittedAIImageDetailItem,
         onLoadDetailImages: @escaping @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailImageSet,
         onToggleLike: @escaping @MainActor (Bool) async -> Bool,
         onDelete: @escaping @MainActor () async -> Bool
@@ -719,17 +719,19 @@ private enum FittedAIImageDetailSheetPreviewData {
     static let handURL = URL(string: "https://picsum.photos/seed/nail-hand/720/720")
     static let referenceURL = URL(string: "https://picsum.photos/seed/nail-reference/720/720")
 
-    static let item = FittedAIImagesViewModel.FittedAIImageItem(
-        jobId: UUID(uuidString: "11111111-2222-3333-4444-555555555555") ?? UUID(),
-        thumbnailURL: generatedURL,
-        fullImageURL: generatedURL,
-        shape: .almond,
-        extensionMode: .extend,
-        createdAt: Date(timeIntervalSince1970: 1_746_662_400),
-        parentJobId: nil,
-        refinementTurn: 0,
-        isLiked: true
-    )
+    static let item: FittedAIImagesViewModel.FittedAIImageDetailItem = {
+        let listItem = FittedAIImagesViewModel.FittedAIImageItem(
+            jobId: UUID(uuidString: "11111111-2222-3333-4444-555555555555") ?? UUID(),
+            thumbnailURL: Self.generatedURL,
+            createdAt: Date(timeIntervalSince1970: 1_746_662_400),
+            isLiked: true
+        )
+        return FittedAIImagesViewModel.previewDetailItem(
+            from: listItem,
+            shape: .almond,
+            extensionMode: .extend
+        )
+    }()
 
     static let detailImageSet = FittedAIImagesViewModel.DetailImageSet(
         generatedURL: generatedURL,

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesLayoutMetrics.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesLayoutMetrics.swift
@@ -17,6 +17,16 @@ struct FittedAIImagesLayoutMetrics: Equatable {
         CGSize(width: tileSide, height: tileSide)
     }
 
+    func initialRevealItemCount(
+        viewportHeight: CGFloat,
+        bufferRows: Int
+    ) -> Int {
+        guard tileSide > 0 else { return columnCount }
+        let rowHeight = max(tileSide + spacing, 1)
+        let visibleRows = max(Int(ceil(max(viewportHeight, tileSide) / rowHeight)), 1)
+        return max(visibleRows + max(bufferRows, 0), 1) * columnCount
+    }
+
     init(
         containerWidth: CGFloat,
         columnCount: Int = 3,
@@ -33,4 +43,9 @@ struct FittedAIImagesLayoutMetrics: Equatable {
         self.containerWidth = resolvedWidth
         self.tileSide = floor(availableWidth / CGFloat(resolvedColumnCount))
     }
+}
+
+struct FittedAIImagesRevealConfig: Hashable {
+    let targetSize: CGSize
+    let visibleCount: Int
 }

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -10,11 +10,15 @@ import NailUI
 struct FittedAIImagesView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
     @StateObject private var viewModel: FittedAIImagesViewModel
-    @State private var selectedItem: FittedAIImagesViewModel.FittedAIImageItem?
+    @State private var selectedItem: FittedAIImagesViewModel.FittedAIImageDetailItem?
     @State private var gridContainerWidth: CGFloat = FittedAIImagesLayoutMetrics.fallbackContainerWidth
     private let loadsOnTask: Bool
     private let gridSpacing: CGFloat = 1
     private let tileCornerRadius: CGFloat = 0
+    private let contentSpacing: CGFloat = 14
+    private let contentTopPadding: CGFloat = 8
+    private let contentBottomPadding: CGFloat = 16
+    private static let scrollCoordinateSpace = "results-tab-scroll"
 
     @MainActor
     init(loadsOnTask: Bool = true) {
@@ -48,47 +52,71 @@ struct FittedAIImagesView: View {
     }
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(spacing: 14) {
-                filterSegment
-                content
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
-            .padding(.bottom, 16)
-        }
-        .background(ProfileDesignTokens.pageBackground.ignoresSafeArea())
-        .navigationTitle("오늘 네일 AI 피팅 결과")
-        .navigationBarTitleDisplayMode(.inline)
-        .scrollBounceBehavior(.always, axes: .vertical)
-        .refreshable {
-            await viewModel.refresh()
-        }
-        .task(id: layoutMetrics.thumbnailTargetSize) {
-            viewModel.updateThumbnailTargetSize(layoutMetrics.thumbnailTargetSize)
-        }
-        .task {
-            guard loadsOnTask else { return }
-            viewModel.bind(service: appViewModel)
-            await viewModel.loadIfNeeded()
-        }
-        .sheet(item: $selectedItem) { item in
-            FittedAIImageDetailSheet(
-                item: item,
-                onLoadDetailImages: { jobId, fallbackGeneratedURL in
-                    try await viewModel.fetchDetailImageSet(
-                        jobId: jobId,
-                        fallbackGeneratedURL: fallbackGeneratedURL
-                    )
-                },
-                onToggleLike: { nextLikeState in
-                    await viewModel.setLike(jobId: item.jobId, isLiked: nextLikeState)
-                },
-                onDelete: {
-                    await viewModel.delete(jobId: item.jobId)
+        GeometryReader { proxy in
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: contentSpacing) {
+                    scrollOffsetSentinel
+                    filterSegment
+                    content
                 }
-            )
+                .padding(.horizontal, 16)
+                .padding(.top, contentTopPadding)
+                .padding(.bottom, contentBottomPadding)
+            }
+            .coordinateSpace(name: Self.scrollCoordinateSpace)
+            .background(ProfileDesignTokens.pageBackground.ignoresSafeArea())
+            .navigationTitle("오늘 네일 AI 피팅 결과")
+            .navigationBarTitleDisplayMode(.inline)
+            .scrollBounceBehavior(.always, axes: .vertical)
+            .refreshable {
+                await viewModel.refresh()
+            }
+            .onPreferenceChange(ResultsTabScrollOffsetPreferenceKey.self) { offset in
+                viewModel.updateScrollOffset(offset)
+            }
+            .onAppear {
+                viewModel.recordScreenEntered()
+            }
+            .task(id: layoutMetrics.thumbnailTargetSize) {
+                _ = proxy.size.height
+                viewModel.updateThumbnailTargetSize(layoutMetrics.thumbnailTargetSize)
+            }
+            .task {
+                guard loadsOnTask else { return }
+                viewModel.bind(service: appViewModel)
+                await viewModel.loadIfNeeded()
+            }
+            .sheet(item: $selectedItem) { item in
+                FittedAIImageDetailSheet(
+                    item: item,
+                    onLoadDetailImages: { jobId, fallbackGeneratedURL in
+                        try await viewModel.fetchDetailImageSet(
+                            jobId: jobId,
+                            fallbackGeneratedURL: fallbackGeneratedURL
+                        )
+                    },
+                    onToggleLike: { nextLikeState in
+                        await viewModel.setLike(jobId: item.jobId, isLiked: nextLikeState)
+                    },
+                    onDelete: {
+                        await viewModel.delete(jobId: item.jobId)
+                    }
+                )
+            }
         }
+    }
+
+    private var scrollOffsetSentinel: some View {
+        Color.clear
+            .frame(height: 0)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: ResultsTabScrollOffsetPreferenceKey.self,
+                        value: max(-proxy.frame(in: .named(Self.scrollCoordinateSpace)).minY, 0)
+                    )
+                }
+            }
     }
 
     private var filterSegment: some View {
@@ -137,8 +165,10 @@ struct FittedAIImagesView: View {
                 listRow(item)
                     .onAppear {
                         viewModel.prefetchNearFutureThumbnails(currentItemID: item.id)
-                        Task {
-                            await viewModel.loadMoreIfNeeded(currentItemID: item.id)
+                        if viewModel.shouldTriggerLoadMore(currentItemID: item.id) {
+                            Task {
+                                await viewModel.loadMoreIfNeeded(currentItemID: item.id)
+                            }
                         }
                     }
             }
@@ -277,7 +307,7 @@ struct FittedAIImagesView: View {
 
         return ZStack {
             Button {
-                selectedItem = item
+                selectedItem = viewModel.detailItem(for: item.jobId)
             } label: {
                 thumbnail(item)
                     .opacity(isDeleting ? 0.55 : 1)
@@ -327,13 +357,14 @@ struct FittedAIImagesView: View {
                         .resizable()
                         .scaledToFill()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .onAppear {
+                            viewModel.recordThumbnailDisplayed(
+                                jobId: item.jobId,
+                                source: item.thumbnailSourceForLog
+                            )
+                        }
                 case .empty:
-                    ZStack {
-                        ProfileDesignTokens.aiHistoryPromptBackground
-                        ProgressView()
-                            .controlSize(.small)
-                            .tint(ProfileDesignTokens.accent)
-                    }
+                    thumbnailPlaceholder(showProgress: true)
                 case .failure:
                     Image(systemName: "photo")
                         .appTypography(size: 20, weight: .medium)
@@ -351,6 +382,25 @@ struct FittedAIImagesView: View {
         .clipShape(RoundedRectangle(cornerRadius: tileCornerRadius, style: .continuous))
     }
 
+    private func thumbnailPlaceholder(showProgress: Bool) -> some View {
+        ZStack {
+            ProfileDesignTokens.aiHistoryPromptBackground
+            if showProgress {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(ProfileDesignTokens.accent)
+            }
+        }
+    }
+
+}
+
+private struct ResultsTabScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
 }
 
 #if DEBUG

--- a/NailClient/NailClientTests/App/NailClientTests.swift
+++ b/NailClient/NailClientTests/App/NailClientTests.swift
@@ -93,7 +93,7 @@ struct NailClientTests {
     }
 
     @Test
-    func start_홈진입시_첫12개썸네일rawbytes를디스크프리패치한다() async throws {
+    func start_홈진입시_결과목록프리로드를수행하지않는다() async {
         let session = AppTestFixtures.makeSession()
         let user = AppTestFixtures.makeUser(nickname: "prefetch-user", profileImageURL: nil)
         let authResult = AppTestFixtures.makeAuthResult(
@@ -108,20 +108,21 @@ struct NailClientTests {
                     parentJobId: nil,
                     refinementTurn: 0,
                     resultImageURL: "https://example.com/result-\(index).jpg",
-                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                    thumbnailImageURL: index.isMultiple(of: 4) ? nil : "https://example.com/thumb-\(index).jpg"
                 )
             },
             nextCursor: "next-page"
         )
         let recorder = ImagePrefetchRecorder()
+        let authService = MockAuthService(
+            behavior: .immediate(authResult),
+            completedNailGenerationListBehavior: .success(
+                response: listResponse,
+                session: session
+            )
+        )
         let viewModel = AppViewModel(
-            authService: MockAuthService(
-                behavior: .immediate(authResult),
-                completedNailGenerationListBehavior: .success(
-                    response: listResponse,
-                    session: session
-                )
-            ),
+            authService: authService,
             imagePrefetch: recorder.prefetch,
             launchTiming: .init(
                 minimumSplashDuration: .milliseconds(10),
@@ -131,13 +132,40 @@ struct NailClientTests {
 
         await viewModel.start()
 
-        #expect(recorder.calls.count == 1)
-        let call = try #require(recorder.calls.first)
-        #expect(call.urls.count == 12)
-        #expect(call.urls == (0..<12).compactMap { URL(string: "https://example.com/thumb-\($0).jpg") })
-        #expect(call.targetSize == nil)
-        #expect(call.resizeMode == .fill)
-        #expect(call.destination == .diskCache)
+        #expect(recorder.calls.isEmpty)
+        #expect(await authService.completedNailGenerationListCallCount == 0)
+    }
+
+    @Test
+    func prepareNailGenerationFirstPage는_항상nil을반환한다() async {
+        let session = AppTestFixtures.makeSession()
+        let user = AppTestFixtures.makeUser(nickname: "shared-preload-user", profileImageURL: nil)
+        let authResult = AppTestFixtures.makeAuthResult(
+            session: session,
+            user: user,
+            needsOnboarding: false
+        )
+        let authService = MockAuthService(
+            behavior: .immediate(authResult),
+            completedNailGenerationListBehavior: .success(
+                response: NailGenListResponse(items: [], nextCursor: nil),
+                session: session
+            )
+        )
+        let viewModel = AppViewModel(
+            authService: authService,
+            launchTiming: .init(
+                minimumSplashDuration: .milliseconds(10),
+                autoLoginTimeout: .milliseconds(120)
+            )
+        )
+
+        await viewModel.start()
+        async let prepared = viewModel.prepareNailGenerationFirstPage(limit: 20, likedOnly: false)
+        let preparedResponse = await prepared
+
+        #expect(preparedResponse == nil)
+        #expect(await authService.completedNailGenerationListCallCount == 0)
     }
 
     @Test

--- a/NailClient/NailClientTests/Features/AIGeneration/AINailGenerationDetailItemTests.swift
+++ b/NailClient/NailClientTests/Features/AIGeneration/AINailGenerationDetailItemTests.swift
@@ -29,7 +29,7 @@ struct AINailGenerationDetailItemTests {
 
         let item = try #require(viewModel.makeAutoOpenedDetailItem(createdAt: createdAt))
         #expect(item.jobId == jobID)
-        #expect(item.fullImageURL == resultURL)
+        #expect(item.generatedImageURL == resultURL)
         #expect(item.thumbnailURL == nil)
         #expect(item.shape == .square)
         #expect(item.extensionMode == .extend)

--- a/NailClient/NailClientTests/Features/AIGeneration/AINailGenerationPushOpenTests.swift
+++ b/NailClient/NailClientTests/Features/AIGeneration/AINailGenerationPushOpenTests.swift
@@ -57,7 +57,7 @@ struct AINailGenerationPushOpenTests {
 
         #expect(outcome == .opened)
         #expect(item.jobId == jobId)
-        #expect(item.fullImageURL?.absoluteString == resultImageURL)
+        #expect(item.generatedImageURL?.absoluteString == resultImageURL)
         #expect(item.thumbnailURL == nil)
         #expect(item.shape == .square)
         #expect(item.extensionMode == .extend)

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesLayoutMetricsTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesLayoutMetricsTests.swift
@@ -27,4 +27,20 @@ struct FittedAIImagesLayoutMetricsTests {
         #expect(metrics.tileSide == 142)
         #expect(metrics.thumbnailTargetSize == CGSize(width: 142, height: 142))
     }
+
+    @Test
+    func viewport기반초기노출개수를_버퍼한행포함으로계산한다() {
+        let metrics = FittedAIImagesLayoutMetrics(
+            containerWidth: 390,
+            columnCount: 3,
+            spacing: 1
+        )
+
+        let itemCount = metrics.initialRevealItemCount(
+            viewportHeight: 360,
+            bufferRows: 1
+        )
+
+        #expect(itemCount == 12)
+    }
 }

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
@@ -11,7 +11,7 @@ import Testing
 @MainActor
 struct FittedAIImagesViewModelTests {
     @Test
-    func 모양과연장모드가_아이템설정값으로매핑된다() async {
+    func 모양과연장모드가_상세아이템설정값으로매핑된다() async {
         let naturalID = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
         let extendID = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
         let unknownID = UUID(uuidString: "cccccccc-cccc-4ccc-8ccc-cccccccccccc")!
@@ -49,12 +49,12 @@ struct FittedAIImagesViewModelTests {
 
         await viewModel.loadIfNeeded()
 
-        #expect(viewModel.items.first(where: { $0.jobId == naturalID })?.shape == .almond)
-        #expect(viewModel.items.first(where: { $0.jobId == naturalID })?.extensionMode == .natural)
-        #expect(viewModel.items.first(where: { $0.jobId == extendID })?.shape == .square)
-        #expect(viewModel.items.first(where: { $0.jobId == extendID })?.extensionMode == .extend)
-        #expect(viewModel.items.first(where: { $0.jobId == unknownID })?.shape == nil)
-        #expect(viewModel.items.first(where: { $0.jobId == unknownID })?.extensionMode == nil)
+        #expect(viewModel.detailItem(for: naturalID)?.shape == .almond)
+        #expect(viewModel.detailItem(for: naturalID)?.extensionMode == .natural)
+        #expect(viewModel.detailItem(for: extendID)?.shape == .square)
+        #expect(viewModel.detailItem(for: extendID)?.extensionMode == .extend)
+        #expect(viewModel.detailItem(for: unknownID)?.shape == nil)
+        #expect(viewModel.detailItem(for: unknownID)?.extensionMode == nil)
     }
 
     @Test
@@ -246,58 +246,25 @@ struct FittedAIImagesViewModelTests {
         await gate.open()
         await loadMoreTask.value
 
-        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.items.map(\.jobId) == [refreshedID, initialID])
         #expect(viewModel.errorMessage == nil)
     }
 
     @Test
-    func loadIfNeeded_캐시히트시_즉시목록표시후_백그라운드재검증반영() async {
-        let cachedID = UUID(uuidString: "10101010-1010-4101-8101-101010101010")!
-        let refreshedID = UUID(uuidString: "20202020-2020-4202-8202-202020202020")!
-
-        let cachedResponse = NailGenListResponse(
-            items: [NailGenerationTestFixtures.makeListItem(jobId: cachedID, parentJobId: nil, refinementTurn: 0)],
-            nextCursor: nil
-        )
-        let refreshedResponse = NailGenListResponse(
-            items: [NailGenerationTestFixtures.makeListItem(jobId: refreshedID, parentJobId: nil, refinementTurn: 0)],
+    func loadIfNeeded는_직접fetch결과로_목록을채운다() async {
+        let fetchedID = UUID(uuidString: "20202020-2020-4202-8202-202020202020")!
+        let fetchedResponse = NailGenListResponse(
+            items: [NailGenerationTestFixtures.makeListItem(jobId: fetchedID, parentJobId: nil, refinementTurn: 0)],
             nextCursor: nil
         )
 
-        let gate = AsyncGate()
-        let service = FittedAIImagesServiceSpy(listResponse: refreshedResponse)
-        service.cachedFirstPageResponses = [
-            .init(limit: 20, likedOnly: false): cachedResponse
-        ]
-        service.fetchHandler = { call, _, cursor, likedOnly in
-            #expect(call == 1)
-            #expect(cursor == nil)
-            #expect(likedOnly == false)
-            await gate.wait()
-            return refreshedResponse
-        }
+        let service = FittedAIImagesServiceSpy(listResponse: fetchedResponse)
 
         let viewModel = FittedAIImagesViewModel()
         viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
 
-        let loadTask = Task {
-            await viewModel.loadIfNeeded()
-        }
-
-        for _ in 0..<50 {
-            if !viewModel.items.isEmpty {
-                break
-            }
-            await Task.yield()
-        }
-
-        #expect(viewModel.items.map(\.jobId) == [cachedID])
-        #expect(viewModel.errorMessage == nil)
-
-        await gate.open()
-        await loadTask.value
-
-        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.items.map(\.jobId) == [fetchedID])
         #expect(viewModel.errorMessage == nil)
         #expect(service.fetchCallCount == 1)
     }
@@ -331,9 +298,136 @@ struct FittedAIImagesViewModelTests {
 
         await viewModel.refresh()
 
-        #expect(viewModel.items.map(\.jobId) == [refreshedID])
+        #expect(viewModel.items.map(\.jobId) == [refreshedID, initialID])
         #expect(viewModel.errorMessage == nil)
         #expect(service.fetchCallCount == 3)
+    }
+
+    @Test
+    func refresh_all필터는_새첫페이지를상단병합하고_tail을유지한다() async {
+        let initialIDs = makeUUIDs(prefix: "74747474-7474-4747-8747", count: 8)
+        let refreshedIDs = makeUUIDs(prefix: "75757575-7575-4757-8757", count: 2)
+
+        let initialResponse = NailGenListResponse(
+            items: [
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[0], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[1], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[2], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[3], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[4], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[5], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[6], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[7], parentJobId: nil, refinementTurn: 0),
+            ],
+            nextCursor: "cursor-initial"
+        )
+        let refreshedResponse = NailGenListResponse(
+            items: [
+                NailGenerationTestFixtures.makeListItem(jobId: refreshedIDs[0], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: refreshedIDs[1], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[3], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[4], parentJobId: nil, refinementTurn: 0),
+                NailGenerationTestFixtures.makeListItem(jobId: initialIDs[5], parentJobId: nil, refinementTurn: 0),
+            ],
+            nextCursor: "cursor-refresh"
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchResultsQueue = [
+            .success(initialResponse),
+            .success(refreshedResponse)
+        ]
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+        await viewModel.refresh()
+
+        #expect(viewModel.items.map(\.jobId) == [
+            refreshedIDs[0],
+            refreshedIDs[1],
+            initialIDs[3],
+            initialIDs[4],
+            initialIDs[5],
+            initialIDs[6],
+            initialIDs[7]
+        ])
+    }
+
+    @Test
+    func refresh_all필터는_overlap이없어도_기존unique목록을tail에유지한다() async {
+        let initialIDs = makeUUIDs(prefix: "76767676-7676-4767-8767", count: 4)
+        let refreshedIDs = makeUUIDs(prefix: "78787878-7878-4787-8787", count: 3)
+
+        let initialResponse = NailGenListResponse(
+            items: initialIDs.map { NailGenerationTestFixtures.makeListItem(jobId: $0, parentJobId: nil, refinementTurn: 0) },
+            nextCursor: "cursor-initial"
+        )
+        let refreshedResponse = NailGenListResponse(
+            items: refreshedIDs.map { NailGenerationTestFixtures.makeListItem(jobId: $0, parentJobId: nil, refinementTurn: 0) },
+            nextCursor: "cursor-refresh"
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialResponse)
+        service.fetchResultsQueue = [
+            .success(initialResponse),
+            .success(refreshedResponse)
+        ]
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+        await viewModel.refresh()
+
+        #expect(viewModel.items.map(\.jobId) == refreshedIDs + initialIDs)
+    }
+
+    @Test
+    func refresh_liked필터는_여전히_replace로동기화한다() async {
+        let initialAllID = UUID(uuidString: "79797979-7979-4797-8797-797979797979")!
+        let initialLikedID = UUID(uuidString: "7a7a7a7a-7a7a-47a7-87a7-7a7a7a7a7a7a")!
+        let refreshedLikedID = UUID(uuidString: "7b7b7b7b-7b7b-47b7-87b7-7b7b7b7b7b7b")!
+
+        let initialAllResponse = NailGenListResponse(
+            items: [NailGenerationTestFixtures.makeListItem(jobId: initialAllID, parentJobId: nil, refinementTurn: 0, isLiked: false)],
+            nextCursor: nil
+        )
+        let initialLikedResponse = NailGenListResponse(
+            items: [NailGenerationTestFixtures.makeListItem(jobId: initialLikedID, parentJobId: nil, refinementTurn: 0, isLiked: true)],
+            nextCursor: nil
+        )
+        let refreshedLikedResponse = NailGenListResponse(
+            items: [NailGenerationTestFixtures.makeListItem(jobId: refreshedLikedID, parentJobId: nil, refinementTurn: 0, isLiked: true)],
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: initialAllResponse)
+        service.fetchHandler = { call, _, cursor, likedOnly in
+            #expect(cursor == nil)
+            switch (call, likedOnly) {
+            case (1, false):
+                return initialAllResponse
+            case (2, true):
+                return initialLikedResponse
+            case (3, true):
+                return refreshedLikedResponse
+            default:
+                return refreshedLikedResponse
+            }
+        }
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+        await viewModel.setFilter(.liked)
+        #expect(viewModel.items.map(\.jobId) == [initialLikedID])
+
+        await viewModel.refresh()
+
+        #expect(viewModel.items.map(\.jobId) == [refreshedLikedID])
     }
 
     @Test
@@ -369,6 +463,8 @@ struct FittedAIImagesViewModelTests {
         let viewModel = FittedAIImagesViewModel()
         viewModel.bind(service: service)
         await viewModel.loadIfNeeded()
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+        viewModel.updateScrollOffset(130)
 
         let first = Task { await viewModel.loadMoreIfNeeded(currentItemID: initialID) }
         let second = Task { await viewModel.loadMoreIfNeeded(currentItemID: initialID) }
@@ -410,7 +506,7 @@ struct FittedAIImagesViewModelTests {
 
         await viewModel.refresh()
 
-        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.items.map(\.jobId) == [initialID])
         #expect(viewModel.errorMessage == "이미지 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
     }
 
@@ -442,7 +538,7 @@ struct FittedAIImagesViewModelTests {
         #expect(viewModel.items.map(\.jobId) == [initialID])
 
         await viewModel.refresh()
-        #expect(viewModel.items.isEmpty)
+        #expect(viewModel.items.map(\.jobId) == [initialID])
         #expect(viewModel.errorMessage == "이미지 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
 
         await viewModel.retry()
@@ -476,13 +572,128 @@ struct FittedAIImagesViewModelTests {
         await viewModel.loadIfNeeded()
 
         let item = try #require(viewModel.items.first)
+        let detailItem = try #require(viewModel.detailItem(for: jobID))
         #expect(item.imageURL?.absoluteString == thumbnailURL)
-        #expect(item.generatedImageURLForDetail?.absoluteString == fullURL)
+        #expect(detailItem.generatedImageURLForDetail?.absoluteString == fullURL)
     }
 
     @Test
-    func 캐시히트후_썸네일크기설정시_앞12개를메모리프리패치한다() async throws {
-        let cachedResponse = NailGenListResponse(
+    func 썸네일URL이없으면_그리드는원본으로fallback하지않고_상세만원본을사용한다() async throws {
+        let jobID = UUID(uuidString: "ffffffff-1111-4fff-8fff-ffffffffffff")!
+        let fullURL = "https://signed.example.com/full-only.png"
+
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(
+                items: [
+                    NailGenerationTestFixtures.makeListItem(
+                        jobId: jobID,
+                        parentJobId: nil,
+                        refinementTurn: 0,
+                        resultImageURL: fullURL,
+                        thumbnailImageURL: nil
+                    )
+                ],
+                nextCursor: nil
+            )
+        )
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+
+        let item = try #require(viewModel.items.first)
+        let detailItem = try #require(viewModel.detailItem(for: jobID))
+        #expect(item.imageURL == nil)
+        #expect(detailItem.generatedImageURLForDetail?.absoluteString == fullURL)
+    }
+
+    @Test
+    func loadMore는_임계아이템에서만_트리거된다() async {
+        let ids = (0..<10).map {
+            UUID(uuidString: String(format: "abababab-abab-4aba-8aba-%012d", $0 + 1)) ?? UUID()
+        }
+        let response = NailGenListResponse(
+            items: ids.map { id in
+                NailGenerationTestFixtures.makeListItem(jobId: id, parentJobId: nil, refinementTurn: 0)
+            },
+            nextCursor: "cursor-next"
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: response)
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[4]) == false)
+
+        viewModel.updateScrollOffset(129)
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[4]) == false)
+
+        viewModel.updateScrollOffset(130)
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[3]) == false)
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[4]) == true)
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[5]) == false)
+    }
+
+    @Test
+    func 첫진입직후에는_loadMore가_arm되기전까지_임계아이템이어도_차단된다() async {
+        let ids = (0..<10).map {
+            UUID(uuidString: String(format: "abababab-abab-4aba-9aba-%012d", $0 + 1)) ?? UUID()
+        }
+        let response = NailGenListResponse(
+            items: ids.map { id in
+                NailGenerationTestFixtures.makeListItem(jobId: id, parentJobId: nil, refinementTurn: 0)
+            },
+            nextCursor: "cursor-next"
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: response)
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+        viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
+
+        #expect(viewModel.shouldTriggerLoadMore(currentItemID: ids[4]) == false)
+    }
+
+    @Test
+    func loadIfNeeded는_prepare응답을사용하지않고_직접fetch한다() async {
+        let response = NailGenListResponse(
+            items: (0..<6).map { index in
+                NailGenerationTestFixtures.makeListItem(
+                    jobId: UUID(uuidString: String(format: "acacacac-acac-4aca-8aca-%012d", index + 1)) ?? UUID(),
+                    parentJobId: nil,
+                    refinementTurn: 0,
+                    resultImageURL: "https://example.com/full-\(index).png",
+                    thumbnailImageURL: "https://example.com/thumb-\(index).jpg"
+                )
+            },
+            nextCursor: nil
+        )
+
+        let service = FittedAIImagesServiceSpy(listResponse: response)
+        service.fetchHandler = { _, limit, cursor, likedOnly in
+            #expect(limit == 18)
+            #expect(cursor == nil)
+            #expect(likedOnly == false)
+            return response
+        }
+        service.prepareFirstPageHandler = { _, _ in response }
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+
+        await viewModel.loadIfNeeded()
+
+        #expect(service.prepareCallCount == 0)
+        #expect(service.fetchCallCount == 1)
+        #expect(viewModel.items.map(\.jobId) == response.items.map(\.jobId))
+    }
+
+    @Test
+    func 목록로드후_썸네일크기설정시_앞12개를메모리프리패치한다() async throws {
+        let fetchedResponse = NailGenListResponse(
             items: (0..<15).map { index in
                 NailGenerationTestFixtures.makeListItem(
                     jobId: UUID(uuidString: String(format: "aaaaaaaa-aaaa-4aaa-8aaa-%012d", index + 1)) ?? UUID(),
@@ -495,28 +706,11 @@ struct FittedAIImagesViewModelTests {
             nextCursor: nil
         )
 
-        let gate = AsyncGate()
-        let service = FittedAIImagesServiceSpy(listResponse: cachedResponse)
-        service.cachedFirstPageResponses[.init(limit: 20, likedOnly: false)] = cachedResponse
-        service.fetchHandler = { _, _, _, _ in
-            await gate.wait()
-            return cachedResponse
-        }
-
+        let service = FittedAIImagesServiceSpy(listResponse: fetchedResponse)
         let recorder = ImagePrefetchRecorder()
         let viewModel = FittedAIImagesViewModel(imagePrefetch: recorder.prefetch)
         viewModel.bind(service: service)
-
-        let loadTask = Task {
-            await viewModel.loadIfNeeded()
-        }
-
-        for _ in 0..<50 {
-            if viewModel.items.count == cachedResponse.items.count {
-                break
-            }
-            await Task.yield()
-        }
+        await viewModel.loadIfNeeded()
 
         viewModel.updateThumbnailTargetSize(CGSize(width: 129, height: 129))
 
@@ -524,9 +718,6 @@ struct FittedAIImagesViewModelTests {
         #expect(call.urls.count == 12)
         #expect(call.targetSize == CGSize(width: 129, height: 129))
         #expect(call.destination == .memoryCache)
-
-        await gate.open()
-        await loadTask.value
 
         #expect(recorder.calls.count == 1)
     }
@@ -586,8 +777,9 @@ struct FittedAIImagesViewModelTests {
 
         await viewModel.loadIfNeeded()
         recorder.reset()
+        viewModel.updateScrollOffset(130)
 
-        let currentItemID = try #require(initialIDs.last)
+        let currentItemID = try #require(initialIDs[safe: 4])
         await viewModel.loadMoreIfNeeded(currentItemID: currentItemID)
 
         let call = try #require(recorder.calls.first)
@@ -631,7 +823,7 @@ struct FittedAIImagesViewModelTests {
     }
 
     @Test
-    func 근접구간프리패치는_같은요청을반복호출해도_중복실행하지않는다() async {
+    func 근접구간프리패치는_같은anchor구간에서는_중복실행하지않는다() async {
         let response = NailGenListResponse(
             items: (0..<20).map { index in
                 NailGenerationTestFixtures.makeListItem(
@@ -654,9 +846,9 @@ struct FittedAIImagesViewModelTests {
         await viewModel.loadIfNeeded()
         recorder.reset()
 
-        let currentItemID = response.items[11].jobId
-        viewModel.prefetchNearFutureThumbnails(currentItemID: currentItemID)
-        viewModel.prefetchNearFutureThumbnails(currentItemID: currentItemID)
+        viewModel.prefetchNearFutureThumbnails(currentItemID: response.items[12].jobId)
+        viewModel.prefetchNearFutureThumbnails(currentItemID: response.items[13].jobId)
+        viewModel.prefetchNearFutureThumbnails(currentItemID: response.items[14].jobId)
 
         #expect(recorder.calls.count == 1)
     }
@@ -666,5 +858,11 @@ struct FittedAIImagesViewModelTests {
 private extension Array {
     subscript(safe index: Int) -> Element? {
         indices.contains(index) ? self[index] : nil
+    }
+}
+
+private func makeUUIDs(prefix: String, count: Int) -> [UUID] {
+    (0..<count).map { index in
+        UUID(uuidString: "\(prefix)-\(String(format: "%012d", index + 1))") ?? UUID()
     }
 }

--- a/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
+++ b/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
@@ -51,7 +51,8 @@ enum NailGenerationTestFixtures {
         resultImageURL: String? = nil,
         thumbnailImageURL: String? = nil,
         shape: String = "almond",
-        extensionMode: NailGenExtensionMode? = .natural
+        extensionMode: NailGenExtensionMode? = .natural,
+        isLiked: Bool = false
     ) -> NailGenListItemResponse {
         NailGenListItemResponse(
             jobId: jobId,
@@ -61,7 +62,8 @@ enum NailGenerationTestFixtures {
             extensionMode: extensionMode,
             createdAt: Date(),
             parentJobId: parentJobId,
-            refinementTurn: refinementTurn
+            refinementTurn: refinementTurn,
+            isLiked: isLiked
         )
     }
 }

--- a/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
@@ -39,8 +39,10 @@ actor MockAuthService: AuthServicing {
     let updateMyProfileBehavior: MockUpdateMyProfileBehavior
     let deleteMyAccountBehavior: MockDeleteMyAccountBehavior
     let completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior
+    let completedNailGenerationListHandler: ((Int, String?, Bool) async throws -> (response: NailGenListResponse, session: AppSession))?
     private(set) var clearLocalSessionCallCount: Int = 0
     private(set) var upsertPushTokenCallCount: Int = 0
+    private(set) var completedNailGenerationListCallCount: Int = 0
 
     init(
         behavior: MockAutoLoginBehavior,
@@ -48,7 +50,8 @@ actor MockAuthService: AuthServicing {
         signInWithAppleResult: Result<AuthResult, Error>? = nil,
         updateMyProfileBehavior: MockUpdateMyProfileBehavior = .unsupported,
         deleteMyAccountBehavior: MockDeleteMyAccountBehavior = .unsupported,
-        completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior = .unsupported
+        completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior = .unsupported,
+        completedNailGenerationListHandler: ((Int, String?, Bool) async throws -> (response: NailGenListResponse, session: AppSession))? = nil
     ) {
         self.behavior = behavior
         self.signInWithGoogleResult = signInWithGoogleResult
@@ -56,6 +59,7 @@ actor MockAuthService: AuthServicing {
         self.updateMyProfileBehavior = updateMyProfileBehavior
         self.deleteMyAccountBehavior = deleteMyAccountBehavior
         self.completedNailGenerationListBehavior = completedNailGenerationListBehavior
+        self.completedNailGenerationListHandler = completedNailGenerationListHandler
     }
 
     func tryAutoLogin(traceId: String, timeout: Duration) async throws -> AuthResult? {
@@ -212,6 +216,10 @@ actor MockAuthService: AuthServicing {
         _ = limit
         _ = cursor
         _ = likedOnly
+        completedNailGenerationListCallCount += 1
+        if let completedNailGenerationListHandler {
+            return try await completedNailGenerationListHandler(limit, cursor, likedOnly)
+        }
         switch completedNailGenerationListBehavior {
         case .unsupported:
             throw MockAuthError.unsupported

--- a/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
@@ -14,7 +14,9 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
     var fetchResultsQueue: [Result<NailGenListResponse, Error>] = []
     var fetchHandler: ((Int, Int, String?, Bool) async throws -> NailGenListResponse)?
     var cachedFirstPageResponses: [CacheKey: NailGenListResponse] = [:]
+    var prepareFirstPageHandler: ((Int, Bool) async -> NailGenListResponse?)?
     var preloadCallCount: Int = 0
+    var prepareCallCount: Int = 0
     private(set) var fetchCallCount: Int = 0
 
     init(listResponse: NailGenListResponse) {
@@ -61,6 +63,17 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
         _ = limit
         _ = likedOnly
         preloadCallCount += 1
+    }
+
+    func prepareNailGenerationFirstPage(
+        limit: Int,
+        likedOnly: Bool
+    ) async -> NailGenListResponse? {
+        prepareCallCount += 1
+        if let prepareFirstPageHandler {
+            return await prepareFirstPageHandler(limit, likedOnly)
+        }
+        return cachedFirstPageResponses[.init(limit: limit, likedOnly: likedOnly)]
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {


### PR DESCRIPTION
## Summary
- 결과 탭 목록 아이템을 최소 필드 중심으로 분리했습니다.
- 상세 시트가 목록 응답의 결과 이미지 fallback 없이 동작하도록 정리했습니다.
- 첫 페이지 기본 요청 개수를 18개로 조정했습니다.

## Scope
- In scope: 결과 탭 목록/상세 모델 분리, 첫 페이지 18개 전환, 관련 테스트 정리
- Out of scope: 프로필 진입 제거, shared-schema의 목록 응답 필드 축소

## Validation Results
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bash scripts/ios-warning-gate.sh\n- 수동 확인: results_tab_first_page_ready 로그에서 items=18 확인\n\n## Risk & Rollback\n- 리스크: 결과 탭 상세 시트가 목록 응답의 기존 필드에 암묵적으로 의존하던 경로가 남아 있을 수 있습니다.\n- 롤백: 이 PR의 squash merge commit을 revert하고, 서버 응답 축소는 shared-schema #17 진행 전까지 보류합니다.\n\n## Closes\n- Closes #64\n- Follow-up: shared-schema #17