### PR TITLE
refactor(profile): 생성 결과 보기 프로필 진입 제거

### DIFF
--- a/NailClient/NailClient/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -23,7 +23,6 @@ final class ProfileViewModel: ObservableObject {
 
     enum ComingSoonItem: String, Identifiable, CaseIterable {
         case likedDesigns = "찜한 디자인"
-        case fittedAIImages = "내가 피팅한 AI 이미지"
         case paymentMethods = "결제 수단 관리"
         case settings = "설정"
         case couponsAndPoints = "쿠폰/포인트"

--- a/NailClient/NailClient/Features/Profile/Views/Components/ProfileMenuSectionView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/ProfileMenuSectionView.swift
@@ -8,7 +8,6 @@ import NailUI
 
 enum ProfileMenuRowAction: Equatable {
     case comingSoon(ProfileViewModel.ComingSoonItem)
-    case fittedAIImages
     case settings
     case signOut
 }

--- a/NailClient/NailClient/Features/Profile/Views/ProfileView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/ProfileView.swift
@@ -12,13 +12,8 @@ struct ProfileView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
     @StateObject private var viewModel = ProfileViewModel()
     @State private var showSignOutAlert: Bool = false
-    @State private var isFittedAIImagesPresented: Bool = false
     @State private var isSettingsPresented: Bool = false
     @State private var selectedProfilePhotoItem: PhotosPickerItem?
-
-    private let activityItems: [ProfileMenuRowItem] = [
-        .init(icon: "sparkles", title: "내가 피팅한 AI 이미지", tint: ProfileDesignTokens.accent, action: .fittedAIImages)
-    ]
 
     private let accountItems: [ProfileMenuRowItem] = [
         .init(icon: "gearshape.fill", title: "설정", tint: ProfileDesignTokens.secondaryText, action: .settings),
@@ -64,8 +59,6 @@ struct ProfileView: View {
         switch action {
         case .comingSoon(let item):
             viewModel.showComingSoon(item)
-        case .fittedAIImages:
-            isFittedAIImagesPresented = true
         case .settings:
             isSettingsPresented = true
         case .signOut:
@@ -106,7 +99,6 @@ struct ProfileView: View {
         NavigationStack {
             ProfileScreen(
                 display: headerDisplay,
-                activityItems: activityItems,
                 accountItems: accountItems,
                 selectedPhotoItem: $selectedProfilePhotoItem,
                 isUploadingPhoto: viewModel.isUploadingProfilePhoto,
@@ -115,10 +107,6 @@ struct ProfileView: View {
             )
             .navigationDestination(isPresented: $isSettingsPresented) {
                 SettingsView()
-                    .environmentObject(appViewModel)
-            }
-            .navigationDestination(isPresented: $isFittedAIImagesPresented) {
-                FittedAIImagesView()
                     .environmentObject(appViewModel)
             }
         }
@@ -180,7 +168,6 @@ struct ProfileView: View {
 
 private struct ProfileScreen: View {
     let display: ProfileViewModel.ProfileHeaderDisplay
-    let activityItems: [ProfileMenuRowItem]
     let accountItems: [ProfileMenuRowItem]
     @Binding var selectedPhotoItem: PhotosPickerItem?
     let isUploadingPhoto: Bool
@@ -196,9 +183,6 @@ private struct ProfileScreen: View {
                     isUploadingPhoto: isUploadingPhoto,
                     onTapEditProfile: onTapEditProfile
                 )
-                ProfileMenuSectionView(title: "내 활동", items: activityItems) { action in
-                    onMenuAction(action)
-                }
                 ProfileMenuSectionView(title: "계정 및 설정", items: accountItems) { action in
                     onMenuAction(action)
                 }
@@ -220,9 +204,6 @@ private struct ProfileScreen: View {
             name: "오늘네일러",
             profileImageURL: PreviewFixtures.imageURL(name: "profile-avatar", hue: 0.11)
         ),
-        activityItems: [
-            .init(icon: "sparkles", title: "내가 피팅한 AI 이미지", tint: ProfileDesignTokens.accent, action: .fittedAIImages),
-        ],
         accountItems: [
             .init(icon: "gearshape.fill", title: "설정", tint: ProfileDesignTokens.secondaryText, action: .settings),
             .init(icon: "rectangle.portrait.and.arrow.right", title: "로그아웃", tint: ProfileDesignTokens.destructive, action: .signOut),

--- a/NailClient/NailClientTests/Features/Profile/ProfileViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/ProfileViewModelTests.swift
@@ -38,8 +38,8 @@ struct ProfileViewModelTests {
     func showComingSoon_신규케이스를정상설정한다() {
         let viewModel = ProfileViewModel()
 
-        viewModel.showComingSoon(.fittedAIImages)
-        #expect(viewModel.comingSoonItem == .fittedAIImages)
+        viewModel.showComingSoon(.likedDesigns)
+        #expect(viewModel.comingSoonItem == .likedDesigns)
 
         viewModel.showComingSoon(.settings)
         #expect(viewModel.comingSoonItem == .settings)


### PR DESCRIPTION
## Summary
- 프로필 화면에서 내 활동 섹션과 생성 결과 보기 진입을 제거합니다.
- 생성 결과 보기는 하단 메인 네비게이션에서만 접근하도록 정리합니다.

## Scope
- 프로필 메뉴 액션에서 생성 결과 보기 진입 제거
- 프로필 화면 섹션 정리
- 관련 테스트 기대값 갱신

## Validation Results
- Debug build 통과 (`xcodebuild ... build`)
- NailClientTests 통과 (`xcodebuild ... -only-testing:NailClientTests`)
- warning-gate 통과 (`scripts/ios-warning-gate.sh`)

## Risk & Rollback
- 프로필 화면에서만 생성 결과 보기 진입이 제거됩니다.
- 문제 발생 시 이 PR을 revert 하면 즉시 원복할 수 있습니다.

## Closes
- Closes #67
