### PR TITLE
refactor(detail-sheet): 상세 시트 전체 대기 로딩으로 전환

### DIFF
--- a/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
+++ b/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
@@ -30,6 +30,13 @@ enum NailImagePrefetchDestination: Hashable, Sendable {
     case memoryCache
 }
 
+struct NailImageWarmupRequest: Hashable, Sendable {
+    let id: String
+    let url: URL
+    let targetSize: CGSize
+    let resizeMode: NailImageResizeMode
+}
+
 typealias NailImagePrefetchClosure = @MainActor @Sendable (
     _ urls: [URL],
     _ targetSize: CGSize?,
@@ -118,5 +125,28 @@ enum NailImagePipeline {
         case .memoryCache:
             memoryPrefetcher.startPrefetching(with: requests)
         }
+    }
+
+    static func warmImagesToMemory(
+        requests: [NailImageWarmupRequest]
+    ) async -> Set<String> {
+        var warmedIDs = Set<String>()
+        for request in requests {
+            guard let imageRequest = makeRequest(
+                url: request.url,
+                targetSize: request.targetSize,
+                resizeMode: request.resizeMode
+            ) else {
+                continue
+            }
+
+            do {
+                _ = try await shared.image(for: imageRequest)
+                warmedIDs.insert(request.id)
+            } catch {
+                continue
+            }
+        }
+        return warmedIDs
     }
 }

--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -984,10 +984,13 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
     let resultImageURL: String?
     let handImageURL: String?
     let referenceImageURL: String?
+    let shape: String?
+    let extensionMode: NailGenExtensionMode?
     let errorCode: String?
     let errorMessage: String?
     let parentJobId: String?
     let refinementTurn: Int?
+    let isLiked: Bool?
     let canRefine: Bool?
     let queueMs: Int?
     let processingMs: Int?
@@ -998,10 +1001,13 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         resultImageURL: String?,
         handImageURL: String? = nil,
         referenceImageURL: String? = nil,
+        shape: String? = nil,
+        extensionMode: NailGenExtensionMode? = nil,
         errorCode: String?,
         errorMessage: String?,
         parentJobId: String? = nil,
         refinementTurn: Int? = nil,
+        isLiked: Bool? = nil,
         canRefine: Bool? = nil,
         queueMs: Int? = nil,
         processingMs: Int? = nil,
@@ -1011,10 +1017,13 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         self.resultImageURL = resultImageURL
         self.handImageURL = handImageURL
         self.referenceImageURL = referenceImageURL
+        self.shape = shape
+        self.extensionMode = extensionMode
         self.errorCode = errorCode
         self.errorMessage = errorMessage
         self.parentJobId = parentJobId
         self.refinementTurn = refinementTurn
+        self.isLiked = isLiked
         self.canRefine = canRefine
         self.queueMs = queueMs
         self.processingMs = processingMs
@@ -1026,13 +1035,39 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         case resultImageURL = "result_image_url"
         case handImageURL = "hand_image_url"
         case referenceImageURL = "reference_image_url"
+        case shape
+        case extensionMode = "extension_mode"
         case errorCode = "error_code"
         case errorMessage = "error_message"
         case parentJobId = "parent_job_id"
         case refinementTurn = "refinement_turn"
+        case isLiked = "is_liked"
         case canRefine = "can_refine"
         case queueMs = "queue_ms"
         case processingMs = "processing_ms"
         case totalMs = "total_ms"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        status = try container.decode(NailGenJobStatus.self, forKey: .status)
+        resultImageURL = try container.decodeIfPresent(String.self, forKey: .resultImageURL)
+        handImageURL = try container.decodeIfPresent(String.self, forKey: .handImageURL)
+        referenceImageURL = try container.decodeIfPresent(String.self, forKey: .referenceImageURL)
+        shape = try container.decodeIfPresent(String.self, forKey: .shape)
+        if let rawExtensionMode = try container.decodeIfPresent(String.self, forKey: .extensionMode) {
+            extensionMode = NailGenExtensionMode(apiValue: rawExtensionMode)
+        } else {
+            extensionMode = nil
+        }
+        errorCode = try container.decodeIfPresent(String.self, forKey: .errorCode)
+        errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        parentJobId = try container.decodeIfPresent(String.self, forKey: .parentJobId)
+        refinementTurn = try container.decodeIfPresent(Int.self, forKey: .refinementTurn)
+        isLiked = try container.decodeIfPresent(Bool.self, forKey: .isLiked)
+        canRefine = try container.decodeIfPresent(Bool.self, forKey: .canRefine)
+        queueMs = try container.decodeIfPresent(Int.self, forKey: .queueMs)
+        processingMs = try container.decodeIfPresent(Int.self, forKey: .processingMs)
+        totalMs = try container.decodeIfPresent(Int.self, forKey: .totalMs)
     }
 }

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -178,7 +178,7 @@ struct AINailGenerationView: View {
             FittedAIImageDetailSheet(
                 item: item,
                 onLoadDetailImages: { jobId, fallbackGeneratedURL in
-                    try await loadDetailImageSet(
+                    try await loadDetailLoadResult(
                         jobId: jobId,
                         fallbackGeneratedURL: fallbackGeneratedURL
                     )
@@ -844,15 +844,16 @@ struct AINailGenerationView: View {
         lastAutoOpenedJobId = detailItem.jobId
     }
 
-    private func loadDetailImageSet(
+    private func loadDetailLoadResult(
         jobId: UUID,
         fallbackGeneratedURL: URL?
-    ) async throws -> FittedAIImagesViewModel.DetailImageSet {
+    ) async throws -> FittedAIImagesViewModel.DetailLoadResult {
         let response = try await appViewModel.getNailGenerationJobStatus(
             jobId: jobId,
             includeInputs: true
         )
 
+        let fallbackItem = selectedDetailItem
         let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
         let handURL = response.handImageURL.flatMap(URL.init(string:))
         let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
@@ -860,8 +861,19 @@ struct AINailGenerationView: View {
         return .init(
             generatedURL: generatedURL,
             handURL: handURL,
-            referenceURL: referenceURL
+            referenceURL: referenceURL,
+            shape: parseShape(from: response.shape) ?? fallbackItem?.shape,
+            extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
+            parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
+            refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
+            isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
         )
+    }
+
+    private func parseShape(from rawValue: String?) -> NailGenShape? {
+        guard let normalized = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !normalized.isEmpty else { return nil }
+        return NailGenShape(rawValue: normalized)
     }
 
     private func toggleDetailLike(jobId: UUID, nextLikeState: Bool) async -> Bool {

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -148,10 +148,15 @@ final class FittedAIImagesViewModel: ObservableObject {
     private static let appendedThumbnailPrefetchCount: Int = 12
     private static let nearFutureThumbnailPrefetchCount: Int = 9
 
-    struct DetailImageSet: Equatable {
+    struct DetailLoadResult: Equatable {
         let generatedURL: URL?
         let handURL: URL?
         let referenceURL: URL?
+        let shape: NailGenShape?
+        let extensionMode: NailGenExtensionMode?
+        let parentJobId: UUID?
+        let refinementTurn: Int
+        let isLiked: Bool
     }
 
     enum ListFilter: String, CaseIterable, Identifiable {
@@ -461,14 +466,15 @@ final class FittedAIImagesViewModel: ObservableObject {
         likingJobIDs.contains(jobId)
     }
 
-    func fetchDetailImageSet(
+    func fetchDetailLoadResult(
         jobId: UUID,
         fallbackGeneratedURL: URL?
-    ) async throws -> DetailImageSet {
+    ) async throws -> DetailLoadResult {
         guard let service else {
             throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
         }
 
+        let fallbackItem = detailItemsByID[jobId]
         let response = try await service.getNailGenerationJobStatus(
             jobId: jobId,
             includeInputs: true
@@ -476,10 +482,15 @@ final class FittedAIImagesViewModel: ObservableObject {
         let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
         let handURL = response.handImageURL.flatMap(URL.init(string:))
         let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
-        return DetailImageSet(
+        return DetailLoadResult(
             generatedURL: generatedURL,
             handURL: handURL,
-            referenceURL: referenceURL
+            referenceURL: referenceURL,
+            shape: Self.parseShape(from: response.shape) ?? fallbackItem?.shape,
+            extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
+            parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
+            refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
+            isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
         )
     }
 

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -4,6 +4,7 @@
 //
 
 import Photos
+import OSLog
 import SwiftUI
 import UIKit
 import NailUI
@@ -34,18 +35,24 @@ struct FittedAIImageDetailSheet: View {
         }
     }
 
+    private enum GalleryResolvedAsset: Equatable {
+        case image(URL)
+        case placeholder
+    }
+
     @Environment(\.dismiss) private var dismiss
     let item: FittedAIImagesViewModel.FittedAIImageDetailItem
-    let onLoadDetailImages: @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailImageSet
+    let onLoadDetailImages: @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailLoadResult
     let onToggleLike: @MainActor (Bool) async -> Bool
     let onDelete: @MainActor () async -> Bool
 
     @State private var isLikeUpdating: Bool = false
     @State private var isLiked: Bool
     @State private var selectedGalleryIndex: Int = 0
-    @State private var detailImageSet: FittedAIImagesViewModel.DetailImageSet
+    @State private var detailLoadResult: FittedAIImagesViewModel.DetailLoadResult?
+    @State private var resolvedGalleryAssets: [GallerySlot: GalleryResolvedAsset] = [:]
     @State private var isGalleryLoading: Bool = false
-    @State private var hasLoadedDetailImages: Bool = false
+    @State private var hasRevealedGallery: Bool = false
     @State private var galleryErrorMessage: String?
     @State private var activeAlert: AlertMessage?
     @State private var isDeleting: Bool = false
@@ -54,10 +61,12 @@ struct FittedAIImageDetailSheet: View {
     @State private var contentHeight: CGFloat = 0
     @State private var viewportHeight: CGFloat = 0
     @State private var isScrollEnabled: Bool = false
+    @State private var detailOpenedAt: Date = .now
+    @State private var didLogDetailOpen: Bool = false
 
     init(
         item: FittedAIImagesViewModel.FittedAIImageDetailItem,
-        onLoadDetailImages: @escaping @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailImageSet,
+        onLoadDetailImages: @escaping @MainActor (UUID, URL?) async throws -> FittedAIImagesViewModel.DetailLoadResult,
         onToggleLike: @escaping @MainActor (Bool) async -> Bool,
         onDelete: @escaping @MainActor () async -> Bool
     ) {
@@ -66,13 +75,6 @@ struct FittedAIImageDetailSheet: View {
         self.onToggleLike = onToggleLike
         self.onDelete = onDelete
         _isLiked = State(initialValue: item.isLiked)
-        _detailImageSet = State(
-            initialValue: .init(
-                generatedURL: item.generatedImageURLForDetail,
-                handURL: nil,
-                referenceURL: nil
-            )
-        )
     }
 
     var body: some View {
@@ -110,9 +112,10 @@ struct FittedAIImageDetailSheet: View {
                 await loadDetailImagesIfNeeded()
             }
             .onAppear {
-                prefetchAdjacentGalleryImages(around: selectedGalleryIndex)
+                logDetailOpenedIfNeeded()
             }
             .onChange(of: selectedGalleryIndex) { _, nextIndex in
+                guard hasRevealedGallery else { return }
                 prefetchAdjacentGalleryImages(around: nextIndex)
             }
             .onPreferenceChange(DetailSheetContentHeightPreferenceKey.self) { nextHeight in
@@ -168,7 +171,7 @@ struct FittedAIImageDetailSheet: View {
     @ViewBuilder
     private var gallerySection: some View {
         VStack(spacing: 12) {
-            if isGalleryLoading && !hasLoadedDetailImages {
+            if !hasRevealedGallery {
                 gallerySkeleton
             } else {
                 TabView(selection: $selectedGalleryIndex) {
@@ -358,23 +361,21 @@ struct FittedAIImageDetailSheet: View {
     }
 
     private func galleryURL(for slot: GallerySlot) -> URL? {
-        switch slot {
-        case .generated:
-            return detailImageSet.generatedURL
-        case .hand:
-            return detailImageSet.handURL
-        case .reference:
-            return detailImageSet.referenceURL
+        switch resolvedGalleryAssets[slot] {
+        case let .image(url):
+            return url
+        case .placeholder, nil:
+            return nil
         }
     }
 
     private var selectedShapeOption: AINailShape? {
-        guard let shape = item.shape else { return nil }
+        guard let shape = detailLoadResult?.shape ?? item.shape else { return nil }
         return AINailShape(rawValue: shape.rawValue)
     }
 
     private var extensionModeDisplayText: String? {
-        switch item.extensionMode {
+        switch detailLoadResult?.extensionMode ?? item.extensionMode {
         case .extend:
             return "연장"
         case .natural:
@@ -475,22 +476,47 @@ struct FittedAIImageDetailSheet: View {
 
     private func loadDetailImagesIfNeeded(force: Bool = false) async {
         guard !isGalleryLoading else { return }
-        if hasLoadedDetailImages && !force { return }
+        if hasRevealedGallery && !force { return }
 
         isGalleryLoading = true
         if force {
             galleryErrorMessage = nil
+            hasRevealedGallery = false
         }
         defer { isGalleryLoading = false }
 
         do {
             let loaded = try await onLoadDetailImages(item.jobId, item.generatedImageURLForDetail)
-            detailImageSet = loaded
-            hasLoadedDetailImages = true
+            logDetailStatusReady()
+            let resolvedAssets = await resolveGalleryAssets(from: loaded)
+            detailLoadResult = loaded
+            isLiked = loaded.isLiked
+            resolvedGalleryAssets = resolvedAssets
             galleryErrorMessage = nil
+            hasRevealedGallery = true
+            logDetailAssetsResolved(resolvedAssets)
+            logDetailRevealed()
+            prefetchAdjacentGalleryImages(around: selectedGalleryIndex)
         } catch {
-            hasLoadedDetailImages = true
+            let fallback = FittedAIImagesViewModel.DetailLoadResult(
+                generatedURL: item.generatedImageURLForDetail,
+                handURL: nil,
+                referenceURL: nil,
+                shape: item.shape,
+                extensionMode: item.extensionMode,
+                parentJobId: item.parentJobId,
+                refinementTurn: item.refinementTurn,
+                isLiked: item.isLiked
+            )
+            let resolvedAssets = await resolveGalleryAssets(from: fallback)
+            detailLoadResult = fallback
+            isLiked = fallback.isLiked
+            resolvedGalleryAssets = resolvedAssets
             galleryErrorMessage = "입력 이미지를 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
+            hasRevealedGallery = true
+            logDetailAssetsResolved(resolvedAssets)
+            logDetailRevealed()
+            prefetchAdjacentGalleryImages(around: selectedGalleryIndex)
         }
     }
 
@@ -524,6 +550,90 @@ struct FittedAIImageDetailSheet: View {
             targetSize: CGSize(width: 420, height: 420),
             resizeMode: .fit
         )
+    }
+
+    private func resolveGalleryAssets(
+        from detail: FittedAIImagesViewModel.DetailLoadResult
+    ) async -> [GallerySlot: GalleryResolvedAsset] {
+        let slotURLs: [GallerySlot: URL?] = [
+            .generated: detail.generatedURL,
+            .hand: detail.handURL,
+            .reference: detail.referenceURL,
+        ]
+
+        let warmupRequests = slotURLs.flatMap { slot, url -> [NailImageWarmupRequest] in
+            guard let url else { return [] }
+            return [
+                NailImageWarmupRequest(
+                    id: "\(slot.id)-main",
+                    url: url,
+                    targetSize: CGSize(width: 720, height: 720),
+                    resizeMode: .fit
+                ),
+                NailImageWarmupRequest(
+                    id: "\(slot.id)-thumb",
+                    url: url,
+                    targetSize: CGSize(width: 180, height: 180),
+                    resizeMode: .fill
+                )
+            ]
+        }
+        let warmedIDs = await NailImagePipeline.warmImagesToMemory(requests: warmupRequests)
+
+        var resolvedAssets: [GallerySlot: GalleryResolvedAsset] = [:]
+        for slot in GallerySlot.allCases {
+            guard let url = slotURLs[slot] ?? nil else {
+                resolvedAssets[slot] = .placeholder
+                continue
+            }
+
+            let mainID = "\(slot.id)-main"
+            let thumbID = "\(slot.id)-thumb"
+            if warmedIDs.contains(mainID), warmedIDs.contains(thumbID) {
+                resolvedAssets[slot] = .image(url)
+            } else {
+                resolvedAssets[slot] = .placeholder
+            }
+        }
+
+        return resolvedAssets
+    }
+
+    private func logDetailOpenedIfNeeded() {
+        guard !didLogDetailOpen else { return }
+        didLogDetailOpen = true
+        detailOpenedAt = .now
+        AppLog.ui.debug(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_opened job=\(String(item.jobId.uuidString.prefix(8)), privacy: .public)"
+        )
+    }
+
+    private func logDetailStatusReady() {
+        AppLog.ui.debug(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_status_ready elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
+        )
+    }
+
+    private func logDetailAssetsResolved(_ assets: [GallerySlot: GalleryResolvedAsset]) {
+        let readyCount = assets.values.reduce(into: 0) { count, asset in
+            if case .image = asset {
+                count += 1
+            }
+        }
+        let placeholderCount = assets.count - readyCount
+        AppLog.ui.debug(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_assets_resolved elapsed_ms=\(elapsedMilliseconds, privacy: .public) ready=\(readyCount, privacy: .public) placeholder=\(placeholderCount, privacy: .public)"
+        )
+    }
+
+    private func logDetailRevealed() {
+        AppLog.ui.debug(
+            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_revealed elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
+        )
+    }
+
+    private var elapsedMilliseconds: Int {
+        max(0, Int(Date().timeIntervalSince(detailOpenedAt) * 1000))
     }
 
     private func toggleLike() async {
@@ -567,7 +677,7 @@ struct FittedAIImageDetailSheet: View {
 
     private func downloadGeneratedImage() async {
         guard !isDownloading else { return }
-        guard let targetURL = detailImageSet.generatedURL ?? item.generatedImageURLForDetail else {
+        guard let targetURL = detailLoadResult?.generatedURL ?? item.generatedImageURLForDetail else {
             activeAlert = AlertMessage(
                 id: UUID().uuidString,
                 title: "저장 실패",
@@ -733,10 +843,15 @@ private enum FittedAIImageDetailSheetPreviewData {
         )
     }()
 
-    static let detailImageSet = FittedAIImagesViewModel.DetailImageSet(
+    static let detailLoadResult = FittedAIImagesViewModel.DetailLoadResult(
         generatedURL: generatedURL,
         handURL: handURL,
-        referenceURL: referenceURL
+        referenceURL: referenceURL,
+        shape: .almond,
+        extensionMode: .extend,
+        parentJobId: nil,
+        refinementTurn: 0,
+        isLiked: true
     )
 }
 
@@ -744,7 +859,7 @@ private enum FittedAIImageDetailSheetPreviewData {
     FittedAIImageDetailSheet(
         item: FittedAIImageDetailSheetPreviewData.item,
         onLoadDetailImages: { _, _ in
-            FittedAIImageDetailSheetPreviewData.detailImageSet
+            FittedAIImageDetailSheetPreviewData.detailLoadResult
         },
         onToggleLike: { nextLikeState in
             nextLikeState

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -90,7 +90,7 @@ struct FittedAIImagesView: View {
                 FittedAIImageDetailSheet(
                     item: item,
                     onLoadDetailImages: { jobId, fallbackGeneratedURL in
-                        try await viewModel.fetchDetailImageSet(
+                        try await viewModel.fetchDetailLoadResult(
                             jobId: jobId,
                             fallbackGeneratedURL: fallbackGeneratedURL
                         )

--- a/NailClient/NailClientTests/Core/Networking/EdgeAPIModelTests.swift
+++ b/NailClient/NailClientTests/Core/Networking/EdgeAPIModelTests.swift
@@ -89,4 +89,32 @@ struct EdgeAPIModelTests {
         #expect(decoded.processingMs == 840)
         #expect(decoded.totalMs == 2160)
     }
+
+    @Test
+    func nailGenJobStatusResponse_상세메타필드가_디코딩된다() throws {
+        let json = """
+        {
+          "status": "completed",
+          "result_image_url": "https://signed.example.com/result.jpg",
+          "hand_image_url": "https://signed.example.com/hand.jpg",
+          "reference_image_url": "https://signed.example.com/reference.jpg",
+          "parent_job_id": "11111111-1111-4111-8111-111111111111",
+          "refinement_turn": 2,
+          "shape": "almond",
+          "extension_mode": "EXTEND",
+          "is_liked": true
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(NailGenJobStatusResponse.self, from: Data(json.utf8))
+
+        #expect(decoded.status == .completed)
+        #expect(decoded.shape == "almond")
+        #expect(decoded.extensionMode == .extend)
+        #expect(decoded.isLiked == true)
+        #expect(decoded.handImageURL == "https://signed.example.com/hand.jpg")
+        #expect(decoded.referenceImageURL == "https://signed.example.com/reference.jpg")
+        #expect(decoded.parentJobId == "11111111-1111-4111-8111-111111111111")
+        #expect(decoded.refinementTurn == 2)
+    }
 }

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
@@ -58,6 +58,109 @@ struct FittedAIImagesViewModelTests {
     }
 
     @Test
+    func 상세로드결과는_status응답의메타와이미지URL을우선사용한다() async throws {
+        let jobID = UUID(uuidString: "abababab-abab-4aba-8aba-abababababab")!
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(
+                items: [
+                    NailGenerationTestFixtures.makeListItem(
+                        jobId: jobID,
+                        parentJobId: nil,
+                        refinementTurn: 0,
+                        resultImageURL: "https://example.com/list-full.jpg",
+                        thumbnailImageURL: "https://example.com/list-thumb.jpg",
+                        shape: "almond",
+                        extensionMode: .natural,
+                        isLiked: false
+                    )
+                ],
+                nextCursor: nil
+            )
+        )
+        service.statusResponse = NailGenerationTestFixtures.makeStatusResponse(
+            status: .completed,
+            resultImageURL: "https://example.com/status-full.jpg",
+            handImageURL: "https://example.com/hand.jpg",
+            referenceImageURL: "https://example.com/reference.jpg",
+            parentJobId: "12121212-1212-4121-8121-121212121212",
+            refinementTurn: 2,
+            shape: "square",
+            extensionMode: .extend,
+            isLiked: true
+        )
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+
+        let detail = try await viewModel.fetchDetailLoadResult(
+            jobId: jobID,
+            fallbackGeneratedURL: URL(string: "https://example.com/fallback.jpg")
+        )
+
+        #expect(detail.generatedURL?.absoluteString == "https://example.com/status-full.jpg")
+        #expect(detail.handURL?.absoluteString == "https://example.com/hand.jpg")
+        #expect(detail.referenceURL?.absoluteString == "https://example.com/reference.jpg")
+        #expect(detail.shape == .square)
+        #expect(detail.extensionMode == .extend)
+        #expect(detail.parentJobId?.uuidString.lowercased() == "12121212-1212-4121-8121-121212121212")
+        #expect(detail.refinementTurn == 2)
+        #expect(detail.isLiked == true)
+    }
+
+    @Test
+    func 상세로드결과는_status응답에메타가없으면_목록상세아이템값으로폴백한다() async throws {
+        let parentJobID = UUID(uuidString: "34343434-3434-4343-8343-343434343434")!
+        let jobID = UUID(uuidString: "cdcdcdcd-cdcd-4cdc-8cdc-cdcdcdcdcdcd")!
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(
+                items: [
+                    NailGenerationTestFixtures.makeListItem(
+                        jobId: jobID,
+                        parentJobId: parentJobID,
+                        refinementTurn: 1,
+                        resultImageURL: "https://example.com/list-full.jpg",
+                        thumbnailImageURL: "https://example.com/list-thumb.jpg",
+                        shape: "almond",
+                        extensionMode: .natural,
+                        isLiked: true
+                    )
+                ],
+                nextCursor: nil
+            )
+        )
+        service.statusResponse = NailGenerationTestFixtures.makeStatusResponse(
+            status: .completed,
+            resultImageURL: nil,
+            handImageURL: nil,
+            referenceImageURL: nil,
+            parentJobId: nil,
+            refinementTurn: nil,
+            shape: nil,
+            extensionMode: nil,
+            isLiked: nil
+        )
+
+        let viewModel = FittedAIImagesViewModel()
+        viewModel.bind(service: service)
+        await viewModel.loadIfNeeded()
+
+        let detail = try await viewModel.fetchDetailLoadResult(
+            jobId: jobID,
+            fallbackGeneratedURL: URL(string: "https://example.com/fallback.jpg")
+        )
+
+        #expect(detail.generatedURL?.absoluteString == "https://example.com/fallback.jpg")
+        #expect(detail.handURL == nil)
+        #expect(detail.referenceURL == nil)
+        #expect(detail.shape == .almond)
+        #expect(detail.extensionMode == .natural)
+        #expect(detail.parentJobId == parentJobID)
+        #expect(detail.refinementTurn == 1)
+        #expect(detail.isLiked == true)
+    }
+
+    @Test
     func 삭제성공시_삭제된잡들이_목록에서제거된다() async {
         let rootID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
         let childID = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!

--- a/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
+++ b/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
@@ -27,19 +27,29 @@ enum NailGenerationTestFixtures {
     static func makeStatusResponse(
         status: NailGenJobStatus,
         resultImageURL: String? = nil,
+        handImageURL: String? = nil,
+        referenceImageURL: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil,
         parentJobId: String? = nil,
         refinementTurn: Int? = nil,
-        canRefine: Bool? = nil
+        canRefine: Bool? = nil,
+        shape: String? = nil,
+        extensionMode: NailGenExtensionMode? = nil,
+        isLiked: Bool? = nil
     ) -> NailGenJobStatusResponse {
         NailGenJobStatusResponse(
             status: status,
             resultImageURL: resultImageURL,
+            handImageURL: handImageURL,
+            referenceImageURL: referenceImageURL,
+            shape: shape,
+            extensionMode: extensionMode,
             errorCode: errorCode,
             errorMessage: errorMessage,
             parentJobId: parentJobId,
             refinementTurn: refinementTurn,
+            isLiked: isLiked,
             canRefine: canRefine
         )
     }

--- a/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
@@ -15,6 +15,8 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
     var fetchHandler: ((Int, Int, String?, Bool) async throws -> NailGenListResponse)?
     var cachedFirstPageResponses: [CacheKey: NailGenListResponse] = [:]
     var prepareFirstPageHandler: ((Int, Bool) async -> NailGenListResponse?)?
+    var statusResponse: NailGenJobStatusResponse?
+    var statusError: Error?
     var preloadCallCount: Int = 0
     var prepareCallCount: Int = 0
     private(set) var fetchCallCount: Int = 0
@@ -74,6 +76,18 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
             return await prepareFirstPageHandler(limit, likedOnly)
         }
         return cachedFirstPageResponses[.init(limit: limit, likedOnly: likedOnly)]
+    }
+
+    func getNailGenerationJobStatus(
+        jobId: UUID,
+        includeInputs: Bool
+    ) async throws -> NailGenJobStatusResponse {
+        _ = jobId
+        _ = includeInputs
+        if let statusError {
+            throw statusError
+        }
+        return statusResponse ?? NailGenerationTestFixtures.makeStatusResponse(status: .completed)
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {


### PR DESCRIPTION
## Summary
- 생성 결과 상세 시트가 status 응답과 이미지 준비가 끝난 뒤 갤러리를 한 번에 노출하도록 바꿨습니다.
- 상세 메타와 이미지 URL 소스를 목록 응답이 아닌 `nail-gen-status` 응답 중심으로 정리했습니다.
- 관련 shared-schema 변경은 todays-nail/shared-schema#18, PR [#19](https://github.com/todays-nail/shared-schema/pull/19) 입니다.

## Scope
- In scope: 상세 시트 로딩 경로 정리, detail load result 도입, status 응답 디코딩 확장, 관련 테스트 보강
- Out of scope: `nail-gen-list` 응답 축소, 썸네일 스펙 변경, 캐시 전략 재도입

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests` 통과
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bash scripts/ios-warning-gate.sh` 통과
- App impact classification: backward compatible

## Risk & Rollback
- 서버 변경은 additive 필드만 사용하므로 현재 배포 앱과 충돌하지 않습니다.
- 문제 발생 시 app PR revert 또는 `nail-gen-status` 이전 배포본 재적용으로 롤백 가능합니다.

## Closes
- Closes #69
