### PR TITLE
refactor(detail-sheet): 상세 시트 로딩 지연 계측과 warmup 최적화

### DIFF
--- a/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
+++ b/NailClient/NailClient/Core/ImagePipeline/NailImagePipeline.swift
@@ -130,23 +130,36 @@ enum NailImagePipeline {
     static func warmImagesToMemory(
         requests: [NailImageWarmupRequest]
     ) async -> Set<String> {
-        var warmedIDs = Set<String>()
-        for request in requests {
+        let preparedRequests = requests.compactMap { request -> (String, ImageRequest)? in
             guard let imageRequest = makeRequest(
                 url: request.url,
                 targetSize: request.targetSize,
                 resizeMode: request.resizeMode
             ) else {
-                continue
+                return nil
             }
 
-            do {
-                _ = try await shared.image(for: imageRequest)
-                warmedIDs.insert(request.id)
-            } catch {
-                continue
-            }
+            return (request.id, imageRequest)
         }
-        return warmedIDs
+
+        return await withTaskGroup(of: String?.self) { group in
+            for (requestID, imageRequest) in preparedRequests {
+                group.addTask {
+                    do {
+                        _ = try await shared.image(for: imageRequest)
+                        return requestID
+                    } catch {
+                        return nil
+                    }
+                }
+            }
+
+            var warmedIDs = Set<String>()
+            for await warmedID in group {
+                guard let warmedID else { continue }
+                warmedIDs.insert(warmedID)
+            }
+            return warmedIDs
+        }
     }
 }

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -33,6 +33,8 @@ struct AINailGenerationView: View {
     @State private var lastAppliedDesignPayloadID: UUID?
     @State private var lastAutoOpenedJobId: UUID?
     @State private var isConsentSheetPresented: Bool = false
+    @State private var detailLoadTasks: [UUID: Task<FittedAIImagesViewModel.DetailLoadResult, Error>] = [:]
+    @State private var cachedDetailLoadResults: [UUID: FittedAIImagesViewModel.DetailLoadResult] = [:]
     private let uploadCardSpacing: CGFloat = 12
     private let uploadCardHeight: CGFloat = 180
     private let uploadCardRowHeight: CGFloat = 212
@@ -124,6 +126,8 @@ struct AINailGenerationView: View {
             pushNavigationTask = nil
             designSelectionToastTask?.cancel()
             designSelectionToastTask = nil
+            detailLoadTasks.values.forEach { $0.cancel() }
+            detailLoadTasks.removeAll()
         }
         .onChange(of: appViewModel.selectedAIDesignPayload) { _, _ in
             applySelectedDesignIfNeeded(requireAITab: true, showsToast: true)
@@ -840,6 +844,10 @@ struct AINailGenerationView: View {
         guard let detailItem = viewModel.makeAutoOpenedDetailItem() else { return }
         guard lastAutoOpenedJobId != detailItem.jobId else { return }
 
+        prefetchDetailLoadResult(
+            jobId: detailItem.jobId,
+            fallbackGeneratedURL: detailItem.generatedImageURLForDetail
+        )
         selectedDetailItem = detailItem
         lastAutoOpenedJobId = detailItem.jobId
     }
@@ -848,26 +856,66 @@ struct AINailGenerationView: View {
         jobId: UUID,
         fallbackGeneratedURL: URL?
     ) async throws -> FittedAIImagesViewModel.DetailLoadResult {
-        let response = try await appViewModel.getNailGenerationJobStatus(
+        if let cached = cachedDetailLoadResults[jobId] {
+            return cached
+        }
+
+        if let task = detailLoadTasks[jobId] {
+            let result = try await task.value
+            cachedDetailLoadResults[jobId] = result
+            detailLoadTasks[jobId] = nil
+            return result
+        }
+
+        let task = makeDetailLoadTask(
             jobId: jobId,
-            includeInputs: true
+            fallbackGeneratedURL: fallbackGeneratedURL
         )
+        detailLoadTasks[jobId] = task
+        let result = try await task.value
+        cachedDetailLoadResults[jobId] = result
+        detailLoadTasks[jobId] = nil
+        return result
+    }
 
+    private func prefetchDetailLoadResult(
+        jobId: UUID,
+        fallbackGeneratedURL: URL?
+    ) {
+        guard cachedDetailLoadResults[jobId] == nil else { return }
+        guard detailLoadTasks[jobId] == nil else { return }
+        detailLoadTasks[jobId] = makeDetailLoadTask(
+            jobId: jobId,
+            fallbackGeneratedURL: fallbackGeneratedURL
+        )
+    }
+
+    private func makeDetailLoadTask(
+        jobId: UUID,
+        fallbackGeneratedURL: URL?
+    ) -> Task<FittedAIImagesViewModel.DetailLoadResult, Error> {
         let fallbackItem = selectedDetailItem
-        let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
-        let handURL = response.handImageURL.flatMap(URL.init(string:))
-        let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
+        return Task {
+            let response = try await appViewModel.getNailGenerationJobStatus(
+                jobId: jobId,
+                includeInputs: true
+            )
 
-        return .init(
-            generatedURL: generatedURL,
-            handURL: handURL,
-            referenceURL: referenceURL,
-            shape: parseShape(from: response.shape) ?? fallbackItem?.shape,
-            extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
-            parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
-            refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
-            isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
-        )
+            let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
+            let handURL = response.handImageURL.flatMap(URL.init(string:))
+            let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
+
+            return .init(
+                generatedURL: generatedURL,
+                handURL: handURL,
+                referenceURL: referenceURL,
+                shape: parseShape(from: response.shape) ?? fallbackItem?.shape,
+                extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
+                parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
+                refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
+                isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
+            )
+        }
     }
 
     private func parseShape(from rawValue: String?) -> NailGenShape? {
@@ -885,6 +933,18 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == response.jobId {
                 selectedDetailItem?.isLiked = response.isLiked
             }
+            if let cached = cachedDetailLoadResults[jobId] {
+                cachedDetailLoadResults[jobId] = .init(
+                    generatedURL: cached.generatedURL,
+                    handURL: cached.handURL,
+                    referenceURL: cached.referenceURL,
+                    shape: cached.shape,
+                    extensionMode: cached.extensionMode,
+                    parentJobId: cached.parentJobId,
+                    refinementTurn: cached.refinementTurn,
+                    isLiked: response.isLiked
+                )
+            }
             return true
         } catch {
             return false
@@ -897,6 +957,9 @@ struct AINailGenerationView: View {
             if selectedDetailItem?.jobId == jobId {
                 selectedDetailItem = nil
             }
+            detailLoadTasks[jobId]?.cancel()
+            detailLoadTasks[jobId] = nil
+            cachedDetailLoadResults[jobId] = nil
             return true
         } catch {
             return false

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -247,6 +247,8 @@ final class FittedAIImagesViewModel: ObservableObject {
     private var allItemIndexByID: [UUID: Int] = [:]
     private var likedItemIndexByID: [UUID: Int] = [:]
     private var detailItemsByID: [UUID: FittedAIImageDetailItem] = [:]
+    private var detailLoadTasksByID: [UUID: Task<DetailLoadResult, Error>] = [:]
+    private var cachedDetailLoadResultsByID: [UUID: DetailLoadResult] = [:]
     private var allLastPrefetchAnchor: Int?
     private var likedLastPrefetchAnchor: Int?
     private var resultsTabEnteredAt: Date?
@@ -470,28 +472,68 @@ final class FittedAIImagesViewModel: ObservableObject {
         jobId: UUID,
         fallbackGeneratedURL: URL?
     ) async throws -> DetailLoadResult {
+        if let cached = cachedDetailLoadResultsByID[jobId] {
+            return cached
+        }
+
+        if let task = detailLoadTasksByID[jobId] {
+            let result = try await task.value
+            cachedDetailLoadResultsByID[jobId] = result
+            detailLoadTasksByID[jobId] = nil
+            return result
+        }
+
+        let task = makeDetailLoadTask(jobId: jobId, fallbackGeneratedURL: fallbackGeneratedURL)
+        detailLoadTasksByID[jobId] = task
+        let result = try await task.value
+        cachedDetailLoadResultsByID[jobId] = result
+        detailLoadTasksByID[jobId] = nil
+        return result
+    }
+
+    func prefetchDetailLoadResult(
+        jobId: UUID,
+        fallbackGeneratedURL: URL?
+    ) {
+        guard cachedDetailLoadResultsByID[jobId] == nil else { return }
+        guard detailLoadTasksByID[jobId] == nil else { return }
+
+        detailLoadTasksByID[jobId] = makeDetailLoadTask(
+            jobId: jobId,
+            fallbackGeneratedURL: fallbackGeneratedURL
+        )
+    }
+
+    private func makeDetailLoadTask(
+        jobId: UUID,
+        fallbackGeneratedURL: URL?
+    ) -> Task<DetailLoadResult, Error> {
         guard let service else {
-            throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
+            return Task {
+                throw EdgeAPIError(statusCode: -1, message: "서비스가 연결되지 않았습니다.", errorId: nil)
+            }
         }
 
         let fallbackItem = detailItemsByID[jobId]
-        let response = try await service.getNailGenerationJobStatus(
-            jobId: jobId,
-            includeInputs: true
-        )
-        let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
-        let handURL = response.handImageURL.flatMap(URL.init(string:))
-        let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
-        return DetailLoadResult(
-            generatedURL: generatedURL,
-            handURL: handURL,
-            referenceURL: referenceURL,
-            shape: Self.parseShape(from: response.shape) ?? fallbackItem?.shape,
-            extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
-            parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
-            refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
-            isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
-        )
+        return Task {
+            let response = try await service.getNailGenerationJobStatus(
+                jobId: jobId,
+                includeInputs: true
+            )
+            let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
+            let handURL = response.handImageURL.flatMap(URL.init(string:))
+            let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
+            return DetailLoadResult(
+                generatedURL: generatedURL,
+                handURL: handURL,
+                referenceURL: referenceURL,
+                shape: Self.parseShape(from: response.shape) ?? fallbackItem?.shape,
+                extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
+                parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
+                refinementTurn: response.refinementTurn ?? fallbackItem?.refinementTurn ?? 0,
+                isLiked: response.isLiked ?? fallbackItem?.isLiked ?? false
+            )
+        }
     }
 
     func detailItem(for jobId: UUID) -> FittedAIImageDetailItem? {
@@ -513,6 +555,11 @@ final class FittedAIImagesViewModel: ObservableObject {
             allItems.removeAll { targetIDs.contains($0.jobId) }
             likedItems.removeAll { targetIDs.contains($0.jobId) }
             detailItemsByID = detailItemsByID.filter { !targetIDs.contains($0.key) }
+            for targetID in targetIDs {
+                detailLoadTasksByID[targetID]?.cancel()
+                detailLoadTasksByID[targetID] = nil
+                cachedDetailLoadResultsByID[targetID] = nil
+            }
 
             setError(nil, for: selectedFilter)
             return true
@@ -923,6 +970,19 @@ final class FittedAIImagesViewModel: ObservableObject {
         if var detailItem = detailItemsByID[jobId] {
             detailItem.isLiked = isLiked
             detailItemsByID[jobId] = detailItem
+        }
+
+        if let cached = cachedDetailLoadResultsByID[jobId] {
+            cachedDetailLoadResultsByID[jobId] = DetailLoadResult(
+                generatedURL: cached.generatedURL,
+                handURL: cached.handURL,
+                referenceURL: cached.referenceURL,
+                shape: cached.shape,
+                extensionMode: cached.extensionMode,
+                parentJobId: cached.parentJobId,
+                refinementTurn: cached.refinementTurn,
+                isLiked: isLiked
+            )
         }
 
         if isLiked {

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -63,6 +63,7 @@ struct FittedAIImageDetailSheet: View {
     @State private var isScrollEnabled: Bool = false
     @State private var detailOpenedAt: Date = .now
     @State private var didLogDetailOpen: Bool = false
+    @State private var detailLogId: String = AppLog.makeErrorId()
 
     init(
         item: FittedAIImagesViewModel.FittedAIImageDetailItem,
@@ -485,6 +486,8 @@ struct FittedAIImageDetailSheet: View {
         }
         defer { isGalleryLoading = false }
 
+        logDetailLoadStarted(force: force)
+
         do {
             let loaded = try await onLoadDetailImages(item.jobId, item.generatedImageURLForDetail)
             logDetailStatusReady()
@@ -496,6 +499,7 @@ struct FittedAIImageDetailSheet: View {
             hasRevealedGallery = true
             logDetailAssetsResolved(resolvedAssets)
             logDetailRevealed()
+            prefetchGalleryThumbnails(from: loaded)
             prefetchAdjacentGalleryImages(around: selectedGalleryIndex)
         } catch {
             let fallback = FittedAIImagesViewModel.DetailLoadResult(
@@ -516,6 +520,7 @@ struct FittedAIImageDetailSheet: View {
             hasRevealedGallery = true
             logDetailAssetsResolved(resolvedAssets)
             logDetailRevealed()
+            prefetchGalleryThumbnails(from: fallback)
             prefetchAdjacentGalleryImages(around: selectedGalleryIndex)
         }
     }
@@ -569,16 +574,12 @@ struct FittedAIImageDetailSheet: View {
                     url: url,
                     targetSize: CGSize(width: 720, height: 720),
                     resizeMode: .fit
-                ),
-                NailImageWarmupRequest(
-                    id: "\(slot.id)-thumb",
-                    url: url,
-                    targetSize: CGSize(width: 180, height: 180),
-                    resizeMode: .fill
                 )
             ]
         }
+        logDetailWarmupStarted(requestCount: warmupRequests.count)
         let warmedIDs = await NailImagePipeline.warmImagesToMemory(requests: warmupRequests)
+        logDetailWarmupFinished(requestCount: warmupRequests.count, warmedCount: warmedIDs.count)
 
         var resolvedAssets: [GallerySlot: GalleryResolvedAsset] = [:]
         for slot in GallerySlot.allCases {
@@ -588,8 +589,7 @@ struct FittedAIImageDetailSheet: View {
             }
 
             let mainID = "\(slot.id)-main"
-            let thumbID = "\(slot.id)-thumb"
-            if warmedIDs.contains(mainID), warmedIDs.contains(thumbID) {
+            if warmedIDs.contains(mainID) {
                 resolvedAssets[slot] = .image(url)
             } else {
                 resolvedAssets[slot] = .placeholder
@@ -599,19 +599,44 @@ struct FittedAIImageDetailSheet: View {
         return resolvedAssets
     }
 
+    private func prefetchGalleryThumbnails(from detail: FittedAIImagesViewModel.DetailLoadResult) {
+        let urls = [
+            detail.generatedURL,
+            detail.handURL,
+            detail.referenceURL,
+        ].compactMap { $0 }
+
+        guard !urls.isEmpty else { return }
+
+        NailImagePipeline.prefetch(
+            urls: urls,
+            targetSize: CGSize(width: 180, height: 180),
+            resizeMode: .fill
+        )
+    }
+
     private func logDetailOpenedIfNeeded() {
         guard !didLogDetailOpen else { return }
         didLogDetailOpen = true
         detailOpenedAt = .now
-        AppLog.ui.debug(
-            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_opened job=\(String(item.jobId.uuidString.prefix(8)), privacy: .public)"
-        )
+        detailLogId = AppLog.makeErrorId()
+        logDetail("results_detail_opened job=\(String(item.jobId.uuidString.prefix(8)))")
+    }
+
+    private func logDetailLoadStarted(force: Bool) {
+        logDetail("results_detail_load_started force=\(force)")
     }
 
     private func logDetailStatusReady() {
-        AppLog.ui.debug(
-            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_status_ready elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
-        )
+        logDetail("results_detail_status_ready elapsed_ms=\(elapsedMilliseconds)")
+    }
+
+    private func logDetailWarmupStarted(requestCount: Int) {
+        logDetail("results_detail_warmup_started elapsed_ms=\(elapsedMilliseconds) count=\(requestCount)")
+    }
+
+    private func logDetailWarmupFinished(requestCount: Int, warmedCount: Int) {
+        logDetail("results_detail_warmup_finished elapsed_ms=\(elapsedMilliseconds) count=\(requestCount) warmed=\(warmedCount)")
     }
 
     private func logDetailAssetsResolved(_ assets: [GallerySlot: GalleryResolvedAsset]) {
@@ -621,19 +646,19 @@ struct FittedAIImageDetailSheet: View {
             }
         }
         let placeholderCount = assets.count - readyCount
-        AppLog.ui.debug(
-            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_assets_resolved elapsed_ms=\(elapsedMilliseconds, privacy: .public) ready=\(readyCount, privacy: .public) placeholder=\(placeholderCount, privacy: .public)"
-        )
+        logDetail("results_detail_assets_resolved elapsed_ms=\(elapsedMilliseconds) ready=\(readyCount) placeholder=\(placeholderCount)")
     }
 
     private func logDetailRevealed() {
-        AppLog.ui.debug(
-            "\(AppLog.prefix(AppLog.makeErrorId(), "UI")) results_detail_revealed elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
-        )
+        logDetail("results_detail_revealed elapsed_ms=\(elapsedMilliseconds)")
     }
 
     private var elapsedMilliseconds: Int {
         max(0, Int(Date().timeIntervalSince(detailOpenedAt) * 1000))
+    }
+
+    private func logDetail(_ message: String) {
+        AppLog.ui.debug("\(AppLog.prefix(detailLogId, "UI")) \(message)")
     }
 
     private func toggleLike() async {

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -307,7 +307,12 @@ struct FittedAIImagesView: View {
 
         return ZStack {
             Button {
-                selectedItem = viewModel.detailItem(for: item.jobId)
+                guard let detailItem = viewModel.detailItem(for: item.jobId) else { return }
+                viewModel.prefetchDetailLoadResult(
+                    jobId: detailItem.jobId,
+                    fallbackGeneratedURL: detailItem.generatedImageURLForDetail
+                )
+                selectedItem = detailItem
             } label: {
                 thumbnail(item)
                     .opacity(isDeleting ? 0.55 : 1)


### PR DESCRIPTION
## Summary
- 상세 시트 로딩을 열기 직전부터 선행 시작하도록 정리했습니다.
- reveal 전 warmup 대상을 `main 이미지 3개`로 줄이고, warmup 자체를 병렬화했습니다.
- 상세 로딩 구간별 로그를 추가해 `status`와 이미지 warmup 지연을 분리해 관측할 수 있게 했습니다.

## Scope
- 상세 요청 선행 시작 및 in-flight/cached detail load 재사용
- reveal 전 warmup `6 -> 3`
- `NailImagePipeline.warmImagesToMemory` 병렬화
- `results_detail_*` 로그 추가

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer bash scripts/ios-warning-gate.sh`
- 수동 로그 확인:
  - 기존 `results_detail_revealed = 6141~6768ms`
  - 최신 `results_detail_revealed = 3342ms`
  - `warmup_started count=3` 유지

## Risk & Rollback
- 상세 시트의 첫 노출 정책은 그대로 `전체 대기 후 한 번에 노출`을 유지합니다.
- 문제 발생 시 이 PR만 revert 하면 상세 요청 선행 시작과 warmup 병렬화가 함께 원복됩니다.

## Closes
- Closes #72
