### PR TITLE
refactor(detail-sheet): 상세 표시용 이미지 URL 우선 사용

### DIFF
--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -984,6 +984,9 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
     let resultImageURL: String?
     let handImageURL: String?
     let referenceImageURL: String?
+    let resultDisplayImageURL: String?
+    let handDisplayImageURL: String?
+    let referenceDisplayImageURL: String?
     let shape: String?
     let extensionMode: NailGenExtensionMode?
     let errorCode: String?
@@ -1001,6 +1004,9 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         resultImageURL: String?,
         handImageURL: String? = nil,
         referenceImageURL: String? = nil,
+        resultDisplayImageURL: String? = nil,
+        handDisplayImageURL: String? = nil,
+        referenceDisplayImageURL: String? = nil,
         shape: String? = nil,
         extensionMode: NailGenExtensionMode? = nil,
         errorCode: String?,
@@ -1017,6 +1023,9 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         self.resultImageURL = resultImageURL
         self.handImageURL = handImageURL
         self.referenceImageURL = referenceImageURL
+        self.resultDisplayImageURL = resultDisplayImageURL
+        self.handDisplayImageURL = handDisplayImageURL
+        self.referenceDisplayImageURL = referenceDisplayImageURL
         self.shape = shape
         self.extensionMode = extensionMode
         self.errorCode = errorCode
@@ -1035,6 +1044,9 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         case resultImageURL = "result_image_url"
         case handImageURL = "hand_image_url"
         case referenceImageURL = "reference_image_url"
+        case resultDisplayImageURL = "result_display_image_url"
+        case handDisplayImageURL = "hand_display_image_url"
+        case referenceDisplayImageURL = "reference_display_image_url"
         case shape
         case extensionMode = "extension_mode"
         case errorCode = "error_code"
@@ -1054,6 +1066,9 @@ struct NailGenJobStatusResponse: Decodable, Sendable {
         resultImageURL = try container.decodeIfPresent(String.self, forKey: .resultImageURL)
         handImageURL = try container.decodeIfPresent(String.self, forKey: .handImageURL)
         referenceImageURL = try container.decodeIfPresent(String.self, forKey: .referenceImageURL)
+        resultDisplayImageURL = try container.decodeIfPresent(String.self, forKey: .resultDisplayImageURL)
+        handDisplayImageURL = try container.decodeIfPresent(String.self, forKey: .handDisplayImageURL)
+        referenceDisplayImageURL = try container.decodeIfPresent(String.self, forKey: .referenceDisplayImageURL)
         shape = try container.decodeIfPresent(String.self, forKey: .shape)
         if let rawExtensionMode = try container.decodeIfPresent(String.self, forKey: .extensionMode) {
             extensionMode = NailGenExtensionMode(apiValue: rawExtensionMode)

--- a/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
+++ b/NailClient/NailClient/Features/AIGeneration/Views/AINailGenerationView.swift
@@ -901,14 +901,21 @@ struct AINailGenerationView: View {
                 includeInputs: true
             )
 
-            let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
-            let handURL = response.handImageURL.flatMap(URL.init(string:))
-            let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
+            let generatedURL = response.resultDisplayImageURL.flatMap(URL.init(string:))
+                ?? response.resultImageURL.flatMap(URL.init(string:))
+                ?? fallbackGeneratedURL
+            let handURL = response.handDisplayImageURL.flatMap(URL.init(string:))
+                ?? response.handImageURL.flatMap(URL.init(string:))
+            let referenceURL = response.referenceDisplayImageURL.flatMap(URL.init(string:))
+                ?? response.referenceImageURL.flatMap(URL.init(string:))
 
             return .init(
                 generatedURL: generatedURL,
                 handURL: handURL,
                 referenceURL: referenceURL,
+                generatedSource: response.resultDisplayImageURL.flatMap(URL.init(string:)) != nil ? .display : .original,
+                handSource: response.handDisplayImageURL.flatMap(URL.init(string:)) != nil ? .display : .original,
+                referenceSource: response.referenceDisplayImageURL.flatMap(URL.init(string:)) != nil ? .display : .original,
                 shape: parseShape(from: response.shape) ?? fallbackItem?.shape,
                 extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
                 parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
@@ -938,6 +945,9 @@ struct AINailGenerationView: View {
                     generatedURL: cached.generatedURL,
                     handURL: cached.handURL,
                     referenceURL: cached.referenceURL,
+                    generatedSource: cached.generatedSource,
+                    handSource: cached.handSource,
+                    referenceSource: cached.referenceSource,
                     shape: cached.shape,
                     extensionMode: cached.extensionMode,
                     parentJobId: cached.parentJobId,

--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -148,10 +148,18 @@ final class FittedAIImagesViewModel: ObservableObject {
     private static let appendedThumbnailPrefetchCount: Int = 12
     private static let nearFutureThumbnailPrefetchCount: Int = 9
 
+    enum DetailAssetSource: String, Equatable {
+        case display
+        case original
+    }
+
     struct DetailLoadResult: Equatable {
         let generatedURL: URL?
         let handURL: URL?
         let referenceURL: URL?
+        let generatedSource: DetailAssetSource
+        let handSource: DetailAssetSource
+        let referenceSource: DetailAssetSource
         let shape: NailGenShape?
         let extensionMode: NailGenExtensionMode?
         let parentJobId: UUID?
@@ -520,13 +528,28 @@ final class FittedAIImagesViewModel: ObservableObject {
                 jobId: jobId,
                 includeInputs: true
             )
-            let generatedURL = response.resultImageURL.flatMap(URL.init(string:)) ?? fallbackGeneratedURL
-            let handURL = response.handImageURL.flatMap(URL.init(string:))
-            let referenceURL = response.referenceImageURL.flatMap(URL.init(string:))
+            let (generatedURL, generatedSource) = Self.selectDetailAssetURL(
+                displayURL: response.resultDisplayImageURL,
+                originalURL: response.resultImageURL,
+                fallbackURL: fallbackGeneratedURL
+            )
+            let (handURL, handSource) = Self.selectDetailAssetURL(
+                displayURL: response.handDisplayImageURL,
+                originalURL: response.handImageURL,
+                fallbackURL: nil
+            )
+            let (referenceURL, referenceSource) = Self.selectDetailAssetURL(
+                displayURL: response.referenceDisplayImageURL,
+                originalURL: response.referenceImageURL,
+                fallbackURL: nil
+            )
             return DetailLoadResult(
                 generatedURL: generatedURL,
                 handURL: handURL,
                 referenceURL: referenceURL,
+                generatedSource: generatedSource,
+                handSource: handSource,
+                referenceSource: referenceSource,
                 shape: Self.parseShape(from: response.shape) ?? fallbackItem?.shape,
                 extensionMode: response.extensionMode ?? fallbackItem?.extensionMode,
                 parentJobId: response.parentJobId.flatMap(UUID.init(uuidString:)) ?? fallbackItem?.parentJobId,
@@ -977,6 +1000,9 @@ final class FittedAIImagesViewModel: ObservableObject {
                 generatedURL: cached.generatedURL,
                 handURL: cached.handURL,
                 referenceURL: cached.referenceURL,
+                generatedSource: cached.generatedSource,
+                handSource: cached.handSource,
+                referenceSource: cached.referenceSource,
                 shape: cached.shape,
                 extensionMode: cached.extensionMode,
                 parentJobId: cached.parentJobId,
@@ -1188,6 +1214,24 @@ final class FittedAIImagesViewModel: ObservableObject {
         guard let raw = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
               !raw.isEmpty else { return nil }
         return NailGenShape(rawValue: raw)
+    }
+
+    private static func selectDetailAssetURL(
+        displayURL: String?,
+        originalURL: String?,
+        fallbackURL: URL?
+    ) -> (URL?, DetailAssetSource) {
+        if let displayURL,
+           let url = URL(string: displayURL) {
+            return (url, .display)
+        }
+
+        if let originalURL,
+           let url = URL(string: originalURL) {
+            return (url, .original)
+        }
+
+        return (fallbackURL, .original)
     }
 
     private static func makeIndexMap(_ items: [FittedAIImageItem]) -> [UUID: Int] {

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -497,6 +497,7 @@ struct FittedAIImageDetailSheet: View {
             resolvedGalleryAssets = resolvedAssets
             galleryErrorMessage = nil
             hasRevealedGallery = true
+            logDetailAssetSource(loaded)
             logDetailAssetsResolved(resolvedAssets)
             logDetailRevealed()
             prefetchGalleryThumbnails(from: loaded)
@@ -506,6 +507,9 @@ struct FittedAIImageDetailSheet: View {
                 generatedURL: item.generatedImageURLForDetail,
                 handURL: nil,
                 referenceURL: nil,
+                generatedSource: .original,
+                handSource: .original,
+                referenceSource: .original,
                 shape: item.shape,
                 extensionMode: item.extensionMode,
                 parentJobId: item.parentJobId,
@@ -518,6 +522,7 @@ struct FittedAIImageDetailSheet: View {
             resolvedGalleryAssets = resolvedAssets
             galleryErrorMessage = "입력 이미지를 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
             hasRevealedGallery = true
+            logDetailAssetSource(fallback)
             logDetailAssetsResolved(resolvedAssets)
             logDetailRevealed()
             prefetchGalleryThumbnails(from: fallback)
@@ -647,6 +652,12 @@ struct FittedAIImageDetailSheet: View {
         }
         let placeholderCount = assets.count - readyCount
         logDetail("results_detail_assets_resolved elapsed_ms=\(elapsedMilliseconds) ready=\(readyCount) placeholder=\(placeholderCount)")
+    }
+
+    private func logDetailAssetSource(_ detail: FittedAIImagesViewModel.DetailLoadResult) {
+        logDetail(
+            "results_detail_asset_source generated=\(detail.generatedSource.rawValue) hand=\(detail.handSource.rawValue) reference=\(detail.referenceSource.rawValue)"
+        )
     }
 
     private func logDetailRevealed() {
@@ -872,6 +883,9 @@ private enum FittedAIImageDetailSheetPreviewData {
         generatedURL: generatedURL,
         handURL: handURL,
         referenceURL: referenceURL,
+        generatedSource: .display,
+        handSource: .display,
+        referenceSource: .display,
         shape: .almond,
         extensionMode: .extend,
         parentJobId: nil,

--- a/NailClient/NailClient/PreviewSupport/AppViewModel+Preview.swift
+++ b/NailClient/NailClient/PreviewSupport/AppViewModel+Preview.swift
@@ -252,6 +252,7 @@ private actor PreviewAuthService: AuthServicing {
             NailGenJobStatusResponse(
                 status: .completed,
                 resultImageURL: "https://example.com/result-\(jobId.uuidString).jpg",
+                resultDisplayImageURL: "https://example.com/result-display-\(jobId.uuidString).jpg",
                 errorCode: nil,
                 errorMessage: nil,
                 parentJobId: nil,

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
@@ -82,6 +82,9 @@ struct FittedAIImagesViewModelTests {
             resultImageURL: "https://example.com/status-full.jpg",
             handImageURL: "https://example.com/hand.jpg",
             referenceImageURL: "https://example.com/reference.jpg",
+            resultDisplayImageURL: "https://example.com/status-display.jpg",
+            handDisplayImageURL: "https://example.com/hand-display.jpg",
+            referenceDisplayImageURL: "https://example.com/reference-display.jpg",
             parentJobId: "12121212-1212-4121-8121-121212121212",
             refinementTurn: 2,
             shape: "square",
@@ -98,9 +101,12 @@ struct FittedAIImagesViewModelTests {
             fallbackGeneratedURL: URL(string: "https://example.com/fallback.jpg")
         )
 
-        #expect(detail.generatedURL?.absoluteString == "https://example.com/status-full.jpg")
-        #expect(detail.handURL?.absoluteString == "https://example.com/hand.jpg")
-        #expect(detail.referenceURL?.absoluteString == "https://example.com/reference.jpg")
+        #expect(detail.generatedURL?.absoluteString == "https://example.com/status-display.jpg")
+        #expect(detail.handURL?.absoluteString == "https://example.com/hand-display.jpg")
+        #expect(detail.referenceURL?.absoluteString == "https://example.com/reference-display.jpg")
+        #expect(detail.generatedSource == .display)
+        #expect(detail.handSource == .display)
+        #expect(detail.referenceSource == .display)
         #expect(detail.shape == .square)
         #expect(detail.extensionMode == .extend)
         #expect(detail.parentJobId?.uuidString.lowercased() == "12121212-1212-4121-8121-121212121212")
@@ -151,8 +157,11 @@ struct FittedAIImagesViewModelTests {
         )
 
         #expect(detail.generatedURL?.absoluteString == "https://example.com/fallback.jpg")
+        #expect(detail.generatedSource == .original)
         #expect(detail.handURL == nil)
+        #expect(detail.handSource == .original)
         #expect(detail.referenceURL == nil)
+        #expect(detail.referenceSource == .original)
         #expect(detail.shape == .almond)
         #expect(detail.extensionMode == .natural)
         #expect(detail.parentJobId == parentJobID)

--- a/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
+++ b/NailClient/NailClientTests/TestSupport/Fixtures/NailGenerationTestFixtures.swift
@@ -29,6 +29,9 @@ enum NailGenerationTestFixtures {
         resultImageURL: String? = nil,
         handImageURL: String? = nil,
         referenceImageURL: String? = nil,
+        resultDisplayImageURL: String? = nil,
+        handDisplayImageURL: String? = nil,
+        referenceDisplayImageURL: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil,
         parentJobId: String? = nil,
@@ -38,20 +41,28 @@ enum NailGenerationTestFixtures {
         extensionMode: NailGenExtensionMode? = nil,
         isLiked: Bool? = nil
     ) -> NailGenJobStatusResponse {
-        NailGenJobStatusResponse(
-            status: status,
-            resultImageURL: resultImageURL,
-            handImageURL: handImageURL,
-            referenceImageURL: referenceImageURL,
-            shape: shape,
-            extensionMode: extensionMode,
-            errorCode: errorCode,
-            errorMessage: errorMessage,
-            parentJobId: parentJobId,
-            refinementTurn: refinementTurn,
-            isLiked: isLiked,
-            canRefine: canRefine
-        )
+        let payload: [String: Any?] = [
+            "status": status.rawValue,
+            "result_image_url": resultImageURL,
+            "hand_image_url": handImageURL,
+            "reference_image_url": referenceImageURL,
+            "result_display_image_url": resultDisplayImageURL,
+            "hand_display_image_url": handDisplayImageURL,
+            "reference_display_image_url": referenceDisplayImageURL,
+            "error_code": errorCode,
+            "error_message": errorMessage,
+            "parent_job_id": parentJobId,
+            "refinement_turn": refinementTurn,
+            "can_refine": canRefine,
+            "shape": shape,
+            "extension_mode": extensionMode?.rawValue,
+            "is_liked": isLiked,
+        ]
+
+        let jsonObject = payload.compactMapValues { $0 }
+
+        let data = try! JSONSerialization.data(withJSONObject: jsonObject)
+        return try! JSONDecoder().decode(NailGenJobStatusResponse.self, from: data)
     }
 
     static func makeListItem(


### PR DESCRIPTION
## Summary
- 상세 시트가 display image URL을 우선 사용하도록 정리합니다.
- 기존 원본 URL은 fallback으로 유지합니다.
- 상세 로그에 results_detail_asset_source를 추가합니다.

## Scope
- In scope: detail status response decode 확장, display URL 우선 사용, 상세 로그 보강
- Out of scope: nail-gen-list 응답 축소, display derivative 저장, 추가 자산 파이프라인

## Validation Results
- NailClientTests 통과
- scripts/ios-warning-gate.sh 통과
- 상세 reveal 로그 개선 확인
  - 기존 약 6141~6768ms -> 최근 2943ms

## Risk & Rollback
- additive 필드만 사용하고 기존 원본 URL fallback을 유지합니다.
- 문제 발생 시 PR revert로 이전 경로로 되돌릴 수 있습니다.

## Closes
Closes #75