### PR TITLE
feat(profile): 피드 좋아요 및 삭제 즉시 반영 개선

### DIFF
--- a/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
+++ b/NailClient/NailClient/Features/Profile/ViewModels/FittedAIImagesViewModel.swift
@@ -143,6 +143,19 @@ final class FittedAIImagesViewModel: ObservableObject {
         let didLoad: Bool
     }
 
+    private struct IndexedItemSnapshot {
+        let index: Int
+        let item: FittedAIImageItem
+    }
+
+    private struct DeleteSnapshot {
+        let targetIDs: Set<UUID>
+        let allItems: [IndexedItemSnapshot]
+        let likedItems: [IndexedItemSnapshot]
+        let detailItemsByID: [UUID: FittedAIImageDetailItem]
+        let cachedDetailLoadResultsByID: [UUID: DetailLoadResult]
+    }
+
     private static let listLoadErrorMessage = "이미지 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
     private static let leadingThumbnailPrefetchCount: Int = 12
     private static let appendedThumbnailPrefetchCount: Int = 12
@@ -460,10 +473,6 @@ final class FittedAIImagesViewModel: ObservableObject {
         prefetchThumbnailItems(Array(nextItems), targetSize: targetSize, destination: .memoryCache)
     }
 
-    func isDeleting(jobId: UUID) -> Bool {
-        deletingJobIDs.contains(jobId)
-    }
-
     func isLikeUpdating(jobId: UUID) -> Bool {
         likingJobIDs.contains(jobId)
     }
@@ -540,33 +549,36 @@ final class FittedAIImagesViewModel: ObservableObject {
         detailItemsByID[jobId]
     }
 
-    func delete(jobId: UUID) async -> Bool {
+    func delete(jobId: UUID) -> Bool {
         guard let service else { return false }
-        guard deletingJobIDs.contains(jobId) == false else { return false }
+        let optimisticTargetIDs = optimisticDeleteTargetIDs(startingAt: jobId)
+        guard deletingJobIDs.isDisjoint(with: optimisticTargetIDs) else { return false }
 
-        deletingJobIDs.insert(jobId)
-        defer { deletingJobIDs.remove(jobId) }
+        let snapshot = makeDeleteSnapshot(for: optimisticTargetIDs)
+        deletingJobIDs.formUnion(optimisticTargetIDs)
+        applyDelete(targetIDs: optimisticTargetIDs)
+        setError(nil, for: selectedFilter)
 
-        do {
-            let response = try await service.deleteNailGeneration(jobId: jobId)
-            let deletedIDs = Set(response.deletedJobIDs)
-            let targetIDs = deletedIDs.isEmpty ? Set([jobId]) : deletedIDs
+        _ = Task { @MainActor [weak self] in
+            guard let self else { return }
 
-            allItems.removeAll { targetIDs.contains($0.jobId) }
-            likedItems.removeAll { targetIDs.contains($0.jobId) }
-            detailItemsByID = detailItemsByID.filter { !targetIDs.contains($0.key) }
-            for targetID in targetIDs {
-                detailLoadTasksByID[targetID]?.cancel()
-                detailLoadTasksByID[targetID] = nil
-                cachedDetailLoadResultsByID[targetID] = nil
+            defer {
+                self.deletingJobIDs.subtract(optimisticTargetIDs)
             }
 
-            setError(nil, for: selectedFilter)
-            return true
-        } catch {
-            setError("이미지 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.", for: selectedFilter)
-            return false
+            do {
+                let response = try await service.deleteNailGeneration(jobId: jobId)
+                let confirmedTargetIDs = Set(response.deletedJobIDs).isEmpty ? Set([jobId]) : Set(response.deletedJobIDs)
+                let additionalTargetIDs = confirmedTargetIDs.subtracting(snapshot.targetIDs)
+                self.applyDelete(targetIDs: additionalTargetIDs)
+                self.setError(nil, for: self.selectedFilter)
+            } catch {
+                self.restoreDeleteSnapshot(snapshot)
+                self.setError("이미지 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.", for: self.selectedFilter)
+            }
         }
+
+        return true
     }
 
     func toggleLike(jobId: UUID) async -> Bool {
@@ -586,6 +598,7 @@ final class FittedAIImagesViewModel: ObservableObject {
         let previousAllItems = allItems
         let previousLikedItems = likedItems
         let previousDetailItem = detailItemsByID[jobId]
+        let previousCachedDetailLoadResult = cachedDetailLoadResultsByID[jobId]
 
         likingJobIDs.insert(jobId)
         applyLikeState(jobId: jobId, isLiked: isLiked)
@@ -598,10 +611,17 @@ final class FittedAIImagesViewModel: ObservableObject {
             setError(nil, for: selectedFilter)
             return true
         } catch {
-            allItems = previousAllItems
-            likedItems = previousLikedItems
+            setItems(previousAllItems, for: .all)
+            setItems(previousLikedItems, for: .liked)
             if let previousDetailItem {
                 detailItemsByID[jobId] = previousDetailItem
+            } else {
+                detailItemsByID.removeValue(forKey: jobId)
+            }
+            if let previousCachedDetailLoadResult {
+                cachedDetailLoadResultsByID[jobId] = previousCachedDetailLoadResult
+            } else {
+                cachedDetailLoadResultsByID.removeValue(forKey: jobId)
             }
             setError("좋아요 상태 변경에 실패했어요. 잠시 후 다시 시도해 주세요.", for: selectedFilter)
             return false
@@ -767,11 +787,28 @@ final class FittedAIImagesViewModel: ObservableObject {
                 cursor: cursor,
                 likedOnly: filter.likedOnly
             )
-            let detailItems = response.items.map(Self.makeDetailItem)
+            let items = response.items.compactMap { item -> FittedAIImageItem? in
+                guard !self.deletingJobIDs.contains(item.jobId) else { return nil }
+                var mappedItem = Self.makeItem(item)
+                if self.likingJobIDs.contains(item.jobId), let currentItem = self.item(by: item.jobId) {
+                    mappedItem.isLiked = currentItem.isLiked
+                }
+                guard !filter.likedOnly || mappedItem.isLiked else { return nil }
+                return mappedItem
+            }
+            let detailItems = response.items.compactMap { item -> FittedAIImageDetailItem? in
+                guard !self.deletingJobIDs.contains(item.jobId) else { return nil }
+                var detailItem = Self.makeDetailItem(item)
+                if self.likingJobIDs.contains(item.jobId), let currentItem = self.item(by: item.jobId) {
+                    detailItem.isLiked = currentItem.isLiked
+                }
+                guard !filter.likedOnly || detailItem.isLiked else { return nil }
+                return detailItem
+            }
 
             return FetchPageResult(
                 response: response,
-                items: response.items.map(Self.makeItem),
+                items: items,
                 detailItemsByID: Dictionary(uniqueKeysWithValues: detailItems.map { ($0.jobId, $0) }),
                 nextCursor: response.nextCursor
             )
@@ -986,16 +1023,92 @@ final class FittedAIImagesViewModel: ObservableObject {
         }
 
         if isLiked {
+            var updatedLikedItems = likedItems
             if let index = likedItems.firstIndex(where: { $0.jobId == jobId }) {
-                likedItems[index].isLiked = true
+                updatedLikedItems[index].isLiked = true
             } else if var target = item(by: jobId) {
                 target.isLiked = true
-                likedItems.append(target)
-                likedItems.sort(by: Self.sortByNewest)
+                updatedLikedItems.append(target)
+                updatedLikedItems.sort(by: Self.sortByNewest)
             }
+            setItems(updatedLikedItems, for: .liked)
         } else {
-            likedItems.removeAll { $0.jobId == jobId }
+            setItems(likedItems.filter { $0.jobId != jobId }, for: .liked)
         }
+    }
+
+    private func optimisticDeleteTargetIDs(startingAt jobId: UUID) -> Set<UUID> {
+        var targetIDs: Set<UUID> = [jobId]
+        var queue: [UUID] = [jobId]
+
+        while let currentJobID = queue.popLast() {
+            let childIDs = detailItemsByID.values.compactMap { detailItem -> UUID? in
+                detailItem.parentJobId == currentJobID ? detailItem.jobId : nil
+            }
+
+            for childID in childIDs where targetIDs.insert(childID).inserted {
+                queue.append(childID)
+            }
+        }
+
+        return targetIDs
+    }
+
+    private func makeDeleteSnapshot(for targetIDs: Set<UUID>) -> DeleteSnapshot {
+        DeleteSnapshot(
+            targetIDs: targetIDs,
+            allItems: allItems.enumerated().compactMap { index, item in
+                guard targetIDs.contains(item.jobId) else { return nil }
+                return IndexedItemSnapshot(index: index, item: item)
+            },
+            likedItems: likedItems.enumerated().compactMap { index, item in
+                guard targetIDs.contains(item.jobId) else { return nil }
+                return IndexedItemSnapshot(index: index, item: item)
+            },
+            detailItemsByID: detailItemsByID.filter { targetIDs.contains($0.key) },
+            cachedDetailLoadResultsByID: cachedDetailLoadResultsByID.filter { targetIDs.contains($0.key) }
+        )
+    }
+
+    private func applyDelete(targetIDs: Set<UUID>) {
+        guard !targetIDs.isEmpty else { return }
+
+        setItems(allItems.filter { !targetIDs.contains($0.jobId) }, for: .all)
+        setItems(likedItems.filter { !targetIDs.contains($0.jobId) }, for: .liked)
+        detailItemsByID = detailItemsByID.filter { !targetIDs.contains($0.key) }
+
+        for targetID in targetIDs {
+            detailLoadTasksByID[targetID]?.cancel()
+            detailLoadTasksByID[targetID] = nil
+            cachedDetailLoadResultsByID[targetID] = nil
+        }
+    }
+
+    private func restoreDeleteSnapshot(_ snapshot: DeleteSnapshot) {
+        restoreIndexedItems(snapshot.allItems, for: .all)
+        restoreIndexedItems(snapshot.likedItems, for: .liked)
+
+        for (jobId, detailItem) in snapshot.detailItemsByID {
+            detailItemsByID[jobId] = detailItem
+        }
+        for (jobId, cachedResult) in snapshot.cachedDetailLoadResultsByID {
+            cachedDetailLoadResultsByID[jobId] = cachedResult
+        }
+    }
+
+    private func restoreIndexedItems(_ snapshots: [IndexedItemSnapshot], for filter: ListFilter) {
+        guard !snapshots.isEmpty else { return }
+
+        var restoredItems = items(for: filter)
+        var restoredIDs = Set(restoredItems.map(\.jobId))
+
+        for snapshot in snapshots.sorted(by: { $0.index < $1.index }) {
+            guard restoredIDs.insert(snapshot.item.jobId).inserted else { continue }
+            let insertionIndex = min(snapshot.index, restoredItems.count)
+            restoredItems.insert(snapshot.item, at: insertionIndex)
+        }
+
+        setItems(restoredItems, for: filter)
     }
 
     private static func sortByNewest(_ lhs: FittedAIImageItem, _ rhs: FittedAIImageItem) -> Bool {

--- a/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
+++ b/NailClient/NailClient/Features/Profile/Views/Components/FittedAIImageDetailSheet.swift
@@ -55,7 +55,6 @@ struct FittedAIImageDetailSheet: View {
     @State private var hasRevealedGallery: Bool = false
     @State private var galleryErrorMessage: String?
     @State private var activeAlert: AlertMessage?
-    @State private var isDeleting: Bool = false
     @State private var isDownloading: Bool = false
     @State private var showDeleteConfirmAlert: Bool = false
     @State private var contentHeight: CGFloat = 0
@@ -127,13 +126,11 @@ struct FittedAIImageDetailSheet: View {
                 viewportHeight = nextHeight
                 updateScrollState()
             }
-            .interactiveDismissDisabled(isDeleting)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("닫기") {
                         dismiss()
                     }
-                    .disabled(isDeleting)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
@@ -144,7 +141,7 @@ struct FittedAIImageDetailSheet: View {
                             .foregroundStyle(isLiked ? ProfileDesignTokens.destructive : ProfileDesignTokens.primaryText)
                     }
                     .buttonStyle(.plain)
-                    .disabled(isLikeUpdating || isDeleting)
+                    .disabled(isLikeUpdating)
                     .transaction { transaction in
                         transaction.animation = nil
                     }
@@ -425,17 +422,17 @@ struct FittedAIImageDetailSheet: View {
             DetailSheetActionButton(
                 title: isDownloading ? "저장 중..." : "AI 네일 저장하기",
                 variant: .primary,
-                isDisabled: isDownloading || isDeleting
+                isDisabled: isDownloading
             ) {
                 Task { await downloadGeneratedImage() }
             }
             .accessibilityLabel("AI 네일 저장하기")
 
             DetailSheetActionButton(
-                title: isDeleting ? "삭제 중..." : "삭제하기",
+                title: "삭제하기",
                 variant: .destructive,
                 role: .destructive,
-                isDisabled: isDeleting
+                isDisabled: false
             ) {
                 showDeleteConfirmAlert = true
             }
@@ -683,11 +680,6 @@ struct FittedAIImageDetailSheet: View {
     }
 
     private func deleteItem() async {
-        guard !isDeleting else { return }
-
-        isDeleting = true
-        defer { isDeleting = false }
-
         let succeeded = await onDelete()
         if succeeded {
             dismiss()

--- a/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
+++ b/NailClient/NailClient/Features/Profile/Views/FittedAIImagesView.swift
@@ -99,7 +99,7 @@ struct FittedAIImagesView: View {
                         await viewModel.setLike(jobId: item.jobId, isLiked: nextLikeState)
                     },
                     onDelete: {
-                        await viewModel.delete(jobId: item.jobId)
+                        viewModel.delete(jobId: item.jobId)
                     }
                 )
             }
@@ -302,50 +302,32 @@ struct FittedAIImagesView: View {
     }
 
     private func listRow(_ item: FittedAIImagesViewModel.FittedAIImageItem) -> some View {
-        let isDeleting = viewModel.isDeleting(jobId: item.jobId)
         let isLikeUpdating = viewModel.isLikeUpdating(jobId: item.jobId)
 
-        return ZStack {
-            Button {
-                guard let detailItem = viewModel.detailItem(for: item.jobId) else { return }
-                viewModel.prefetchDetailLoadResult(
-                    jobId: detailItem.jobId,
-                    fallbackGeneratedURL: detailItem.generatedImageURLForDetail
-                )
-                selectedItem = detailItem
-            } label: {
-                thumbnail(item)
-                    .opacity(isDeleting ? 0.55 : 1)
-            }
-            .buttonStyle(PressScaleButtonStyle())
-            .disabled(isDeleting)
+        return Button {
+            guard let detailItem = viewModel.detailItem(for: item.jobId) else { return }
+            viewModel.prefetchDetailLoadResult(
+                jobId: detailItem.jobId,
+                fallbackGeneratedURL: detailItem.generatedImageURLForDetail
+            )
+            selectedItem = detailItem
+        } label: {
+            thumbnail(item)
         }
+        .buttonStyle(PressScaleButtonStyle())
         .overlay(alignment: .topTrailing) {
-            if isDeleting {
-                ProgressView()
-                    .controlSize(.small)
-                    .padding(8)
-                    .background(
-                        Circle()
-                            .fill(ProfileDesignTokens.pageBackground.opacity(0.92))
-                    )
-                    .padding(2)
-                    .allowsHitTesting(false)
-            } else {
-                Button {
-                    Task { _ = await viewModel.toggleLike(jobId: item.jobId) }
-                } label: {
-                    Image(systemName: item.isLiked ? "heart.fill" : "heart")
-                        .appTypography(size: 20, weight: .bold)
-                        .foregroundStyle(item.isLiked ? ProfileDesignTokens.destructive : ProfileDesignTokens.secondaryText)
-                        .frame(width: 48, height: 48)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(isLikeUpdating)
-                .opacity(isLikeUpdating ? 0.85 : 1)
-                .padding(2)
+            Button {
+                Task { _ = await viewModel.toggleLike(jobId: item.jobId) }
+            } label: {
+                Image(systemName: item.isLiked ? "heart.fill" : "heart")
+                    .appTypography(size: 20, weight: .bold)
+                    .foregroundStyle(item.isLiked ? ProfileDesignTokens.destructive : ProfileDesignTokens.secondaryText)
+                    .frame(width: 48, height: 48)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .disabled(isLikeUpdating)
+            .padding(2)
         }
     }
 

--- a/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
+++ b/NailClient/NailClientTests/Features/Profile/FittedAIImagesViewModelTests.swift
@@ -161,10 +161,132 @@ struct FittedAIImagesViewModelTests {
     }
 
     @Test
-    func 삭제성공시_삭제된잡들이_목록에서제거된다() async {
+    func 좋아요성공시_서버응답전에도_즉시반영된다() async {
+        let jobID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+        let item = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: jobID, parentJobId: nil, refinementTurn: 0, isLiked: false)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        service.likeHandler = { jobId, isLiked in
+            await gate.wait()
+            return NailGenLikeResponse(ok: true, jobId: jobId, isLiked: isLiked)
+        }
+
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [item],
+            likedItems: []
+        )
+        viewModel.bind(service: service)
+
+        let likeTask = Task {
+            await viewModel.toggleLike(jobId: jobID)
+        }
+        await Task.yield()
+
+        #expect(viewModel.items.map(\.jobId) == [jobID])
+        #expect(viewModel.items.first?.isLiked == true)
+        #expect(viewModel.detailItem(for: jobID)?.isLiked == true)
+
+        await viewModel.setFilter(.liked)
+        #expect(viewModel.items.map(\.jobId) == [jobID])
+
+        await gate.open()
+        let succeeded = await likeTask.value
+
+        #expect(succeeded == true)
+        #expect(viewModel.items.map(\.jobId) == [jobID])
+        #expect(viewModel.items.first?.isLiked == true)
+    }
+
+    @Test
+    func 좋아요실패시_이전상태로롤백된다() async {
+        let jobID = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+        let item = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: jobID, parentJobId: nil, refinementTurn: 0, isLiked: false)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        service.likeHandler = { _, _ in
+            await gate.wait()
+            throw TestSupportError.forced
+        }
+
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [item],
+            likedItems: []
+        )
+        viewModel.bind(service: service)
+
+        let likeTask = Task {
+            await viewModel.toggleLike(jobId: jobID)
+        }
+        await Task.yield()
+
+        #expect(viewModel.items.first?.isLiked == true)
+        #expect(viewModel.detailItem(for: jobID)?.isLiked == true)
+
+        await gate.open()
+        let succeeded = await likeTask.value
+
+        #expect(succeeded == false)
+        #expect(viewModel.items.map(\.jobId) == [jobID])
+        #expect(viewModel.items.first?.isLiked == false)
+        #expect(viewModel.detailItem(for: jobID)?.isLiked == false)
+        #expect(viewModel.errorMessage == "좋아요 상태 변경에 실패했어요. 잠시 후 다시 시도해 주세요.")
+
+        await viewModel.setFilter(.liked)
+        #expect(viewModel.items.isEmpty)
+    }
+
+    @Test
+    func 좋아요요청중_같은잡중복요청은무시된다() async {
+        let jobID = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+        let item = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: jobID, parentJobId: nil, refinementTurn: 0, isLiked: false)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        var likeCallCount = 0
+        service.likeHandler = { jobId, isLiked in
+            likeCallCount += 1
+            await gate.wait()
+            return NailGenLikeResponse(ok: true, jobId: jobId, isLiked: isLiked)
+        }
+
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [item],
+            likedItems: []
+        )
+        viewModel.bind(service: service)
+
+        let firstTask = Task {
+            await viewModel.toggleLike(jobId: jobID)
+        }
+        await Task.yield()
+
+        let secondResult = await viewModel.toggleLike(jobId: jobID)
+
+        #expect(secondResult == false)
+        #expect(likeCallCount == 1)
+
+        await gate.open()
+        let firstResult = await firstTask.value
+
+        #expect(firstResult == true)
+        #expect(likeCallCount == 1)
+    }
+
+    @Test
+    func 삭제시작직후_로컬에로드된자식까지_즉시제거된다() async {
         let rootID = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
         let childID = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
-
         let service = FittedAIImagesServiceSpy(
             listResponse: NailGenListResponse(
                 items: [
@@ -174,68 +296,173 @@ struct FittedAIImagesViewModelTests {
                 nextCursor: nil
             )
         )
+        let gate = AsyncGate()
         service.deleteHandler = { _ in
-            NailGenDeleteResponse(ok: true, deletedJobIDs: [rootID, childID])
+            await gate.wait()
+            return NailGenDeleteResponse(ok: true, deletedJobIDs: [rootID, childID])
         }
 
         let viewModel = FittedAIImagesViewModel()
         viewModel.bind(service: service)
         await viewModel.loadIfNeeded()
 
-        let succeeded = await viewModel.delete(jobId: rootID)
+        let accepted = viewModel.delete(jobId: rootID)
 
-        #expect(succeeded == true)
+        #expect(accepted == true)
         #expect(viewModel.items.isEmpty)
+        #expect(viewModel.detailItem(for: rootID) == nil)
+        #expect(viewModel.detailItem(for: childID) == nil)
+
+        await gate.open()
+        await drainMainActor()
     }
 
     @Test
     func 삭제응답에_deleted_ids가비어있으면_요청한잡만제거한다() async {
-        let firstID = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
-        let secondID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+        let firstID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+        let secondID = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
+        let firstItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: firstID, parentJobId: nil, refinementTurn: 0)
+        )
+        let secondItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: secondID, parentJobId: nil, refinementTurn: 0)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        service.deleteHandler = { _ in
+            await gate.wait()
+            return NailGenDeleteResponse(ok: true, deletedJobIDs: [])
+        }
 
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [firstItem, secondItem],
+            likedItems: []
+        )
+        viewModel.bind(service: service)
+
+        let accepted = viewModel.delete(jobId: secondID)
+
+        #expect(accepted == true)
+        #expect(viewModel.items.map(\.jobId) == [firstID])
+
+        await gate.open()
+        await drainMainActor()
+        #expect(viewModel.items.map(\.jobId) == [firstID])
+    }
+
+    @Test
+    func 삭제실패시_좋아요목록과순서를복원한다() async {
+        let rootID = UUID(uuidString: "66666666-6666-4666-8666-666666666666")!
+        let siblingID = UUID(uuidString: "77777777-7777-4777-8777-777777777777")!
+        let rootItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: rootID, parentJobId: nil, refinementTurn: 0, isLiked: true)
+        )
+        let siblingItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: siblingID, parentJobId: nil, refinementTurn: 0, isLiked: false)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        service.deleteHandler = { _ in
+            await gate.wait()
+            throw TestSupportError.forced
+        }
+
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [rootItem, siblingItem],
+            likedItems: [rootItem]
+        )
+        viewModel.bind(service: service)
+
+        let accepted = viewModel.delete(jobId: rootID)
+
+        #expect(accepted == true)
+        #expect(viewModel.items.map(\.jobId) == [siblingID])
+
+        await gate.open()
+        await drainMainActor()
+
+        #expect(viewModel.items.map(\.jobId) == [rootID, siblingID])
+        #expect(viewModel.errorMessage == "이미지 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.")
+
+        await viewModel.setFilter(.liked)
+        #expect(viewModel.items.map(\.jobId) == [rootID])
+    }
+
+    @Test
+    func 서버삭제응답이_낙관적대상보다넓으면_추가항목도후처리로제거한다() async {
+        let rootID = UUID(uuidString: "88888888-8888-4888-8888-888888888888")!
+        let extraID = UUID(uuidString: "99999999-9999-4999-8999-999999999999")!
+        let rootItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: rootID, parentJobId: nil, refinementTurn: 0)
+        )
+        let extraItem = FittedAIImagesViewModel.makeItem(
+            NailGenerationTestFixtures.makeListItem(jobId: extraID, parentJobId: nil, refinementTurn: 0)
+        )
+        let service = FittedAIImagesServiceSpy(
+            listResponse: NailGenListResponse(items: [], nextCursor: nil)
+        )
+        let gate = AsyncGate()
+        service.deleteHandler = { _ in
+            await gate.wait()
+            return NailGenDeleteResponse(ok: true, deletedJobIDs: [rootID, extraID])
+        }
+
+        let viewModel = FittedAIImagesViewModel.previewState(
+            allItems: [rootItem, extraItem],
+            likedItems: []
+        )
+        viewModel.bind(service: service)
+
+        let accepted = viewModel.delete(jobId: rootID)
+
+        #expect(accepted == true)
+        #expect(viewModel.items.map(\.jobId) == [extraID])
+
+        await gate.open()
+        await drainMainActor()
+
+        #expect(viewModel.items.isEmpty)
+    }
+
+    @Test
+    func 삭제중인대상과겹치는_중복삭제요청은거절된다() async {
+        let rootID = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+        let childID = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
         let service = FittedAIImagesServiceSpy(
             listResponse: NailGenListResponse(
                 items: [
-                    NailGenerationTestFixtures.makeListItem(jobId: firstID, parentJobId: nil, refinementTurn: 0),
-                    NailGenerationTestFixtures.makeListItem(jobId: secondID, parentJobId: nil, refinementTurn: 0),
+                    NailGenerationTestFixtures.makeListItem(jobId: rootID, parentJobId: nil, refinementTurn: 0),
+                    NailGenerationTestFixtures.makeListItem(jobId: childID, parentJobId: rootID, refinementTurn: 1),
                 ],
                 nextCursor: nil
             )
         )
+        let gate = AsyncGate()
+        var deleteCallCount = 0
         service.deleteHandler = { _ in
-            NailGenDeleteResponse(ok: true, deletedJobIDs: [])
+            deleteCallCount += 1
+            await gate.wait()
+            return NailGenDeleteResponse(ok: true, deletedJobIDs: [rootID, childID])
         }
 
         let viewModel = FittedAIImagesViewModel()
         viewModel.bind(service: service)
         await viewModel.loadIfNeeded()
 
-        let succeeded = await viewModel.delete(jobId: secondID)
+        let firstAccepted = viewModel.delete(jobId: rootID)
+        let secondAccepted = viewModel.delete(jobId: childID)
 
-        #expect(succeeded == true)
-        #expect(viewModel.items.map(\.jobId) == [firstID])
-    }
+        #expect(firstAccepted == true)
+        #expect(secondAccepted == false)
+        await drainMainActor()
+        #expect(deleteCallCount == 1)
 
-    @Test
-    func 삭제실패시_에러메시지를노출하고_목록을유지한다() async {
-        let rootID = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
-        let service = FittedAIImagesServiceSpy(
-            listResponse: NailGenListResponse(
-                items: [NailGenerationTestFixtures.makeListItem(jobId: rootID, parentJobId: nil, refinementTurn: 0)],
-                nextCursor: nil
-            )
-        )
-        service.deleteError = TestSupportError.forced
-
-        let viewModel = FittedAIImagesViewModel()
-        viewModel.bind(service: service)
-        await viewModel.loadIfNeeded()
-
-        let succeeded = await viewModel.delete(jobId: rootID)
-
-        #expect(succeeded == false)
-        #expect(viewModel.items.map(\.jobId) == [rootID])
-        #expect(viewModel.errorMessage == "이미지 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.")
+        await gate.open()
+        await drainMainActor()
     }
 
     @Test
@@ -967,5 +1194,12 @@ private extension Array {
 private func makeUUIDs(prefix: String, count: Int) -> [UUID] {
     (0..<count).map { index in
         UUID(uuidString: "\(prefix)-\(String(format: "%012d", index + 1))") ?? UUID()
+    }
+}
+
+@MainActor
+private func drainMainActor(iterations: Int = 10) async {
+    for _ in 0..<iterations {
+        await Task.yield()
     }
 }

--- a/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/FittedAIImagesServiceSpy.swift
@@ -9,6 +9,8 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
     }
 
     let listResponse: NailGenListResponse
+    var likeHandler: ((UUID, Bool) async throws -> NailGenLikeResponse)?
+    var likeError: Error?
     var deleteHandler: ((UUID) async throws -> NailGenDeleteResponse)?
     var deleteError: Error?
     var fetchResultsQueue: [Result<NailGenListResponse, Error>] = []
@@ -91,7 +93,13 @@ final class FittedAIImagesServiceSpy: FittedAIImagesServicing {
     }
 
     func setNailGenerationLike(jobId: UUID, isLiked: Bool) async throws -> NailGenLikeResponse {
-        NailGenLikeResponse(ok: true, jobId: jobId, isLiked: isLiked)
+        if let likeError {
+            throw likeError
+        }
+        if let likeHandler {
+            return try await likeHandler(jobId, isLiked)
+        }
+        return NailGenLikeResponse(ok: true, jobId: jobId, isLiked: isLiked)
     }
 
     func deleteNailGeneration(jobId: UUID) async throws -> NailGenDeleteResponse {


### PR DESCRIPTION
## Summary
- 프로필 피드에서 좋아요를 누르면 서버 응답 전에도 UI가 즉시 반영되도록 정리했습니다.
- 프로필 피드 삭제를 낙관적 삭제로 전환해 삭제 확인 직후 목록과 상세 캐시에서 바로 제거되도록 변경했습니다.
- 실패 시 롤백과 중복 요청 방지 로직을 보강하고 관련 뷰모델 테스트를 추가했습니다.

## Domain
client-app-ios

## Scope
In scope:
- 프로필 피드 좋아요 버튼 즉시 반영 UX 정리
- 프로필 피드 삭제 낙관적 처리 및 실패 복원
- 관련 서비스 스파이와 뷰모델 테스트 보강

Out of scope:
- DB/API 계약 변경
- Undo 토스트 추가
- 다른 화면의 좋아요/삭제 UX 변경

## Validation Results
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests/FittedAIImagesViewModelTests -derivedDataPath /tmp/dd-feat-76-optimistic-feed-actions`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -only-testing:NailClientTests -derivedDataPath /tmp/dd-feat-76-optimistic-feed-actions`

## Risk & Rollback
- Risk: 삭제 낙관적 처리와 서버 응답 후처리가 겹치는 구간에서 목록/상세 캐시 동기화 회귀 가능성
- Rollback: PR revert 또는 삭제 경로를 서버 응답 후 반영 방식으로 되돌리고 즉시 반영 관련 테스트를 함께 복원

## Closes
Closes #76
