### PR TITLE
refactor: iOS warning baseline 정리

### DIFF
--- a/NailClient/WARNING_GATE.md
+++ b/NailClient/WARNING_GATE.md
@@ -16,9 +16,12 @@ bash scripts/ios-warning-gate.sh
 bash scripts/ios-warning-gate.sh --update-baseline
 ```
 
+- baseline 파일은 수동 편집하지 않고 위 스크립트 실행 결과만 반영합니다.
+
 ## 정책
 - `Release(clean build)` + `Debug(simulator build)`를 모두 검사합니다.
 - 앱 소스 신규 경고가 baseline 대비 추가되면 실패합니다.
+- 앱 소스 경고가 0개이면 `NailClient/warning-baseline.txt`가 빈 파일인 상태가 정상입니다.
 - 현재 허용된 도구성 경고:
   - `Metadata extraction skipped. No AppIntents.framework dependency found.`
   - `'UIRequiresFullScreen' has been deprecated ...`

--- a/NailClient/warning-baseline.txt
+++ b/NailClient/warning-baseline.txt
@@ -1,2 +1,0 @@
-NailClient/NailClient/Features/Shop/Services/CurrentRegionProvider.swift: warning: 'CLGeocoder' was deprecated in iOS 26.0: Use MapKit
-NailClient/NailClient/Features/Shop/Services/CurrentRegionProvider.swift: warning: 'reverseGeocodeLocation' was deprecated in iOS 26.0: Use MKReverseGeocodingRequest


### PR DESCRIPTION
## Summary
- stale warning baseline을 현재 코드 상태에 맞게 빈 파일로 재생성했습니다.
- warning gate 문서에 빈 baseline 파일 정책과 스크립트 기반 갱신 규칙을 명시했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `NailClient/warning-baseline.txt` 갱신
- `NailClient/WARNING_GATE.md` 문구 보완
- warning gate 전후 검증

Out of scope:
- 앱 코드 변경
- warning gate 스크립트 계약 변경
- 문서 재배치 또는 자산 정리

## Validation Results
- `bash scripts/ios-warning-gate.sh` 실행으로 stale baseline 안내 재현 확인
- `bash scripts/ios-warning-gate.sh --update-baseline` 실행으로 baseline 재생성
- `bash scripts/ios-warning-gate.sh` 재실행으로 stale baseline 안내 없이 통과 확인
- 최종 결과: 앱 경고 수 `0`, 도구 경고 수(허용) `2`

## Risk & Rollback
- Risk: 향후 앱 경고가 다시 생기면 빈 baseline 파일 대신 새 경고 항목이 기록될 수 있습니다.
- Rollback: PR revert 후 이전 baseline 내용으로 복구합니다.

## Closes
Closes #81