### PR TITLE
test: NailUI 패키지 테스트 타깃 추가

### DIFF
--- a/Packages/NailUI/Package.swift
+++ b/Packages/NailUI/Package.swift
@@ -17,5 +17,9 @@ let package = Package(
         .target(
             name: "NailUI"
         ),
+        .testTarget(
+            name: "NailUITests",
+            dependencies: ["NailUI"]
+        ),
     ]
 )

--- a/Packages/NailUI/Tests/NailUITests/DesignTokenSmokeTests.swift
+++ b/Packages/NailUI/Tests/NailUITests/DesignTokenSmokeTests.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import Testing
+@testable import NailUI
+
+struct DesignTokenSmokeTests {
+    @Test
+    func spacing토큰은_작은값에서큰값순으로증가한다() {
+        #expect(AppSpacingTokens.xxs < AppSpacingTokens.xs)
+        #expect(AppSpacingTokens.xs < AppSpacingTokens.sm)
+        #expect(AppSpacingTokens.sm < AppSpacingTokens.md)
+        #expect(AppSpacingTokens.md < AppSpacingTokens.lg)
+        #expect(AppSpacingTokens.lg < AppSpacingTokens.xl)
+        #expect(AppSpacingTokens.xl < AppSpacingTokens.xxl)
+        #expect(AppSpacingTokens.xxl < AppSpacingTokens.xxxl)
+    }
+
+    @Test
+    func radius토큰은_작은값에서큰값순으로증가한다() {
+        #expect(AppRadiusTokens.sm < AppRadiusTokens.md)
+        #expect(AppRadiusTokens.md < AppRadiusTokens.lg)
+        #expect(AppRadiusTokens.lg < AppRadiusTokens.xl)
+    }
+
+    @Test
+    func typographyTextStyle경계가_의도대로매핑된다() {
+        #expect(AppTypographyTokens.textStyle(for: 11) == .caption2)
+        #expect(AppTypographyTokens.textStyle(for: 12) == .caption)
+        #expect(AppTypographyTokens.textStyle(for: 14) == .footnote)
+        #expect(AppTypographyTokens.textStyle(for: 16) == .subheadline)
+        #expect(AppTypographyTokens.textStyle(for: 18) == .body)
+        #expect(AppTypographyTokens.textStyle(for: 22) == .title3)
+        #expect(AppTypographyTokens.textStyle(for: 27) == .title2)
+        #expect(AppTypographyTokens.textStyle(for: 28) == .largeTitle)
+    }
+}

--- a/Packages/NailUI/Tests/NailUITests/FeedChipPresetTests.swift
+++ b/Packages/NailUI/Tests/NailUITests/FeedChipPresetTests.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+import Testing
+@testable import NailUI
+
+struct FeedChipPresetTests {
+    @Test
+    func category스타일은_선택상태와무관하게동일한레이아웃계약을가진다() {
+        let selected = FeedChipPreset.category(selected: true).style
+        let unselected = FeedChipPreset.category(selected: false).style
+
+        expectCapsule(selected.shape)
+        expectCapsule(unselected.shape)
+        #expect(selected.horizontalPadding == 20)
+        #expect(selected.verticalPadding == 10)
+        #expect(selected.borderWidth == 1)
+        #expect(selected.minWidth == nil)
+        #expect(unselected.horizontalPadding == selected.horizontalPadding)
+        #expect(unselected.verticalPadding == selected.verticalPadding)
+        #expect(unselected.borderWidth == selected.borderWidth)
+    }
+
+    @Test
+    func scheduleDate스타일은_고정최소너비와roundedRectangle형태를가진다() {
+        let style = FeedChipPreset.scheduleDate(selected: true).style
+
+        expectRoundedRectangle(style.shape)
+        #expect(style.cornerRadius == 12)
+        #expect(style.horizontalPadding == 10)
+        #expect(style.verticalPadding == 9)
+        #expect(style.borderWidth == 1)
+        #expect(style.minWidth == 64)
+    }
+
+    @Test
+    func stylePicker스타일은_category보다컴팩트한패딩을사용한다() {
+        let category = FeedChipPreset.category(selected: false).style
+        let stylePicker = FeedChipPreset.stylePicker(selected: false).style
+
+        #expect(stylePicker.horizontalPadding < category.horizontalPadding)
+        #expect(stylePicker.verticalPadding < category.verticalPadding)
+        #expect(stylePicker.borderWidth == 1)
+        #expect(stylePicker.minWidth == nil)
+    }
+
+    private func expectCapsule(_ shape: FeedChipPreset.Style.Shape) {
+        switch shape {
+        case .capsule:
+            break
+        case .roundedRectangle:
+            Issue.record("Expected capsule shape")
+        }
+    }
+
+    private func expectRoundedRectangle(_ shape: FeedChipPreset.Style.Shape) {
+        switch shape {
+        case .roundedRectangle:
+            break
+        case .capsule:
+            Issue.record("Expected roundedRectangle shape")
+        }
+    }
+}

--- a/Packages/NailUI/Tests/NailUITests/PublicUISmokeTests.swift
+++ b/Packages/NailUI/Tests/NailUITests/PublicUISmokeTests.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import Testing
+@testable import NailUI
+
+@MainActor
+struct PublicUISmokeTests {
+    @Test
+    func flowLayout는_전달한spacing을보존한다() {
+        let layout = FlowLayout(spacing: AppSpacingTokens.md)
+
+        #expect(layout.spacing == AppSpacingTokens.md)
+    }
+
+    @Test
+    func skeletonBlock은_초기화인자를그대로보존한다() {
+        let block = SkeletonBlock(
+            width: 120,
+            height: 18,
+            cornerRadius: AppRadiusTokens.sm,
+            shapeStyle: .capsule
+        )
+
+        #expect(block.width == 120)
+        #expect(block.height == 18)
+        #expect(block.cornerRadius == AppRadiusTokens.sm)
+        expectCapsule(block.shapeStyle)
+    }
+
+    @Test
+    func publicView와ButtonStyle은_최소구성으로초기화가능하다() {
+        let style = PressScaleButtonStyle()
+        let markView = NailMarkView()
+        let button = Button("Tap") {}
+            .buttonStyle(style)
+
+        let wrappedMarkView = AnyView(markView)
+        let wrappedButton = AnyView(button)
+
+        #expect(String(describing: type(of: wrappedMarkView)).isEmpty == false)
+        #expect(String(describing: type(of: wrappedButton)).isEmpty == false)
+    }
+
+    private func expectCapsule(_ shapeStyle: SkeletonShapeStyle) {
+        switch shapeStyle {
+        case .capsule:
+            break
+        case .rounded, .circle:
+            Issue.record("Expected capsule skeleton shape")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `Packages/NailUI`에 `NailUITests` 테스트 타깃을 추가했습니다.
- 디자인 토큰, `FeedChipPreset`, 공개 SwiftUI 컴포넌트에 대한 최소 스모크 테스트를 추가했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `Package.swift`에 패키지 테스트 타깃 추가
- 디자인 토큰과 칩 스타일 레이아웃 계약 검증
- 공개 UI 컴포넌트 최소 초기화 스모크 테스트 추가

Out of scope:
- 앱 런타임 코드 변경
- 문서 인덱스 추가
- `todays_nail.icon` 정리 방향 확정

## Validation Results
- `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -scheme NailUI -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /tmp/nailui-package-tests`

## Risk & Rollback
- Risk: 패키지 내부 공개 타입 계약이 바뀌면 새 스모크 테스트가 함께 갱신돼야 합니다.
- Rollback: PR revert 또는 테스트 타깃/테스트 파일 제거로 원복 가능합니다.

## Closes
Closes #87
