### PR TITLE
refactor: iOS warning gate 패키지 변경 감지 보강

### DIFF
--- a/.github/workflows/ios-warning-gate.yml
+++ b/.github/workflows/ios-warning-gate.yml
@@ -21,7 +21,7 @@ jobs:
           set -euo pipefail
           git fetch origin "${{ github.base_ref }}" --depth=1
 
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -Eq '^(\.xcode-version|NailClient/|scripts/ios-warning-gate\.sh|scripts/resolve-xcode-developer-dir\.sh|\.github/workflows/ios-warning-gate\.yml)'; then
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -Eq '^(\.xcode-version|NailClient/|Packages/|scripts/ios-warning-gate\.sh|scripts/resolve-xcode-developer-dir\.sh|\.github/workflows/ios-warning-gate\.yml)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -50,6 +50,6 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         run: bash scripts/ios-warning-gate.sh
 
-      - name: Skip warning gate when iOS files are unchanged
+      - name: Skip warning gate when iOS app and package files are unchanged
         if: steps.detect.outputs.changed != 'true'
-        run: echo "No iOS source changes detected. Skipping warning gate."
+        run: echo "No iOS app or local package changes detected. Skipping warning gate."


### PR DESCRIPTION
## Summary
- `ios-warning-gate` workflow의 변경 감지 범위에 `Packages/`를 추가했습니다.
- package-only 변경에도 warning gate가 skip되지 않도록 메시지와 조건을 정렬했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `.github/workflows/ios-warning-gate.yml`의 변경 감지 범위 수정
- skip 메시지 정렬

Out of scope:
- warning baseline 정책 변경
- 앱 런타임 코드 변경
- 별도 테스트 workflow 추가

## Validation Results
- `printf 'Packages/NailUI/Package.swift\nREADME.md\n' | grep -En '^((\\.xcode-version)|NailClient/|Packages/|scripts/ios-warning-gate\\.sh|scripts/resolve-xcode-developer-dir\\.sh|\\.github/workflows/ios-warning-gate\\.yml)'`
- `git diff --check`

## Risk & Rollback
- Risk: 감지 범위 확장으로 package-only PR에서도 warning gate가 실행되어 CI 시간이 소폭 늘어날 수 있습니다.
- Rollback: workflow 감지식에서 `Packages/` 항목 제거로 원복 가능합니다.

## Closes
Closes #89