### PR TITLE
refactor: iOS 검증 시뮬레이터 대상 정렬

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,9 +131,9 @@ This file is for team-shared conventions only. Keep personal workflow/tool prefe
 ## Verification (Required After Code Changes)
 
 - Build (fast compile check): `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -sdk iphonesimulator build`
-- Unit tests (when logic changes): `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' -only-testing:NailClientTests`
-- UI tests (only when UI flow changes): `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' -only-testing:NailClientUITests`
-- If the simulator name/OS does not exist on a machine, pick an installed one from: `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcrun simctl list devices available`
+- Unit tests (when logic changes): `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:NailClientTests`
+- UI tests (only when UI flow changes): `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -project NailClient/NailClient.xcodeproj -scheme NailClient -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:NailClientUITests`
+- If the simulator name is unavailable or ambiguous on a machine, pick an installed destination from: `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcrun simctl list devices available`
 - CI requirement: keep a shared scheme committed at `NailClient/NailClient.xcodeproj/xcshareddata/xcschemes/NailClient.xcscheme`.
 - If missing, open Xcode and mark `NailClient` scheme as Shared, then commit the generated `.xcscheme` file.
 

--- a/scripts/ios-stable-build.sh
+++ b/scripts/ios-stable-build.sh
@@ -5,9 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_PATH="$ROOT_DIR/NailClient/NailClient.xcodeproj"
 SCHEME="NailClient"
 RESOLVER_PATH="$ROOT_DIR/scripts/resolve-xcode-developer-dir.sh"
-DESTINATION="platform=iOS Simulator,name=iPhone 17,OS=26.0"
+SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-iPhone 17}"
+DESTINATION="${IOS_DESTINATION:-}"
 DURATION_FORMAT=%Y%m%d_%H%M%S
-SIMULATOR_RUNTIME="26.0"
 CLEANUP=0
 LOCK_DIR=""
 
@@ -21,6 +21,9 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: $(basename "$0") [--cleanup] [--help]"
       echo "  --cleanup   Kill orphaned IBAgent/iBtoold/SWBBuildService processes before build"
       echo "  --help      Show this message"
+      echo "Env:"
+      echo "  IOS_SIMULATOR_NAME  Preferred simulator device name (default: iPhone 17)"
+      echo "  IOS_DESTINATION     Full xcodebuild destination override"
       exit 0
       ;;
     *)
@@ -49,6 +52,39 @@ resolve_developer_dir() {
 
   echo "[build] using DEVELOPER_DIR=$DEVELOPER_DIR"
   "$DEVELOPER_DIR/usr/bin/xcodebuild" -version
+}
+
+resolve_destination() {
+  if [[ -n "$DESTINATION" ]]; then
+    echo "[build] using overridden destination=$DESTINATION"
+    return
+  fi
+
+  local runtime
+  runtime="$("$DEVELOPER_DIR/usr/bin/xcodebuild" \
+    -project "$PROJECT_PATH" \
+    -scheme "$SCHEME" \
+    -showdestinations 2>/dev/null | awk -v name="$SIMULATOR_NAME" '
+      $0 ~ "platform:iOS Simulator" && $0 ~ "name:" name "[ }]" {
+        if (match($0, /OS:[^,}]+/)) {
+          runtime = substr($0, RSTART + 3, RLENGTH - 3)
+        }
+      }
+      END { print runtime }
+    ')"
+
+  if [[ -z "$runtime" ]]; then
+    echo "사용 가능한 '$SIMULATOR_NAME' 시뮬레이터를 찾지 못했습니다."
+    echo "설치된 iOS Simulator 대상은 아래와 같습니다:"
+    "$DEVELOPER_DIR/usr/bin/xcodebuild" \
+      -project "$PROJECT_PATH" \
+      -scheme "$SCHEME" \
+      -showdestinations | grep 'platform:iOS Simulator' || true
+    exit 1
+  fi
+
+  DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME,OS=$runtime"
+  echo "[build] using destination=$DESTINATION"
 }
 
 cleanup_tool_processes() {
@@ -151,6 +187,7 @@ run_build() {
 ensure_singleton
 resolve_developer_dir
 validate_developer_dir
+resolve_destination
 cleanup_tool_processes
 check_running_builds
 "$DEVELOPER_DIR/usr/bin/xcodebuild" -version


### PR DESCRIPTION
## Summary
- `ios-stable-build.sh`가 설치된 `iPhone 17` simulator runtime을 자동 해석하도록 수정했습니다.
- `AGENTS.md` 검증 예시에서 고정 OS 값을 제거해 현재 Xcode 환경과 덜 충돌하도록 정리했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `scripts/ios-stable-build.sh` destination/runtime 처리 정리
- `AGENTS.md` 검증 예시 정렬
- 관련 로컬 검증

Out of scope:
- 앱 코드 변경
- Xcode 버전 정책 변경
- CI test workflow 추가

## Validation Results
- `bash scripts/ios-stable-build.sh --help`
- `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild -project NailClient/NailClient.xcodeproj -scheme NailClient -destination 'platform=iOS Simulator,name=iPhone 17' -showBuildSettings`
- `bash scripts/ios-stable-build.sh`
- `git diff --check`

## Risk & Rollback
- Risk: `iPhone 17` 디바이스 이름이 없는 머신에서는 명시적 오류를 내고 종료합니다.
- Rollback: 기존 고정 destination 방식으로 되돌리면 원복 가능합니다.

## Closes
Closes #91