### PR TITLE
test: NailUI 패키지 테스트 CI 추가

### DIFF
--- a/.github/workflows/nailui-package-tests.yml
+++ b/.github/workflows/nailui-package-tests.yml
@@ -1,0 +1,82 @@
+name: nailui-package-tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  nailui-package-tests:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant NailUI changes
+        id: detect
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -Eq '^(\.xcode-version|Packages/NailUI/|scripts/resolve-xcode-developer-dir\.sh|\.github/workflows/nailui-package-tests\.yml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve DEVELOPER_DIR
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          chmod +x scripts/resolve-xcode-developer-dir.sh
+          echo "DEVELOPER_DIR=$(./scripts/resolve-xcode-developer-dir.sh)" >> "$GITHUB_ENV"
+
+      - name: Resolve simulator destination
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          PACKAGE_DIR="$GITHUB_WORKSPACE/Packages/NailUI"
+          SCHEME="NailUI"
+          SIMULATOR_NAME="iPhone 17"
+
+          DESTINATION="$(
+            cd "$PACKAGE_DIR"
+            "$DEVELOPER_DIR/usr/bin/xcodebuild" -scheme "$SCHEME" -showdestinations 2>/dev/null | awk -v name="$SIMULATOR_NAME" '
+              $0 ~ "platform:iOS Simulator" && $0 ~ "name:" name "[ }]" {
+                if (match($0, /OS:[^,}]+/)) {
+                  runtime = substr($0, RSTART + 3, RLENGTH - 3)
+                }
+              }
+              END {
+                if (runtime != "") {
+                  print "platform=iOS Simulator,name=" name ",OS=" runtime
+                }
+              }
+            '
+          )"
+
+          if [[ -z "$DESTINATION" ]]; then
+            echo "Unable to resolve simulator destination for $SIMULATOR_NAME"
+            cd "$PACKAGE_DIR"
+            "$DEVELOPER_DIR/usr/bin/xcodebuild" -scheme "$SCHEME" -showdestinations
+            exit 1
+          fi
+
+          echo "IOS_DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
+          echo "Resolved destination: $DESTINATION"
+
+      - name: Run NailUI package tests
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          cd Packages/NailUI
+          "$DEVELOPER_DIR/usr/bin/xcodebuild" \
+            test \
+            -scheme NailUI \
+            -destination "$IOS_DESTINATION" \
+            -derivedDataPath /tmp/nailui-package-tests
+
+      - name: Skip NailUI package tests when package files are unchanged
+        if: steps.detect.outputs.changed != 'true'
+        run: echo "No NailUI package changes detected. Skipping package tests."

--- a/.github/workflows/nailui-package-tests.yml
+++ b/.github/workflows/nailui-package-tests.yml
@@ -37,31 +37,74 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          PACKAGE_DIR="$GITHUB_WORKSPACE/Packages/NailUI"
-          SCHEME="NailUI"
           SIMULATOR_NAME="iPhone 17"
+          SIMCTL_OUTPUT="$(xcrun simctl list devices available)"
 
-          DESTINATION="$(
-            cd "$PACKAGE_DIR"
-            "$DEVELOPER_DIR/usr/bin/xcodebuild" -scheme "$SCHEME" -showdestinations 2>/dev/null | awk -v name="$SIMULATOR_NAME" '
-              $0 ~ "platform:iOS Simulator" && $0 ~ "name:" name "[ }]" {
-                if (match($0, /OS:[^,}]+/)) {
-                  runtime = substr($0, RSTART + 3, RLENGTH - 3)
+          DESTINATION="$(printf '%s\n' "$SIMCTL_OUTPUT" | awk -v preferred="$SIMULATOR_NAME" '
+            BEGIN {
+              preferred_id = ""
+              fallback_id = ""
+            }
+            /^-- iOS / { runtime = $3 }
+            /\([0-9A-F-]+\) \(Shutdown\)[[:space:]]*$/ || /\([0-9A-F-]+\) \(Booted\)[[:space:]]*$/ {
+              line = $0
+              sub(/^[[:space:]]+/, "", line)
+              name = line
+              sub(/ \([0-9A-F-]+\) \((Shutdown|Booted)\)[[:space:]]*$/, "", name)
+
+              if (match($0, /\([0-9A-F-]+\)/)) {
+                id = substr($0, RSTART + 1, RLENGTH - 2)
+              }
+
+              if (name == preferred && preferred_id == "") {
+                preferred_id = id
+              } else if (fallback_id == "" && name ~ /^iPhone /) {
+                fallback_id = id
+              } else if (fallback_id == "" && name ~ /^iPad /) {
+                fallback_id = id
+              }
+            }
+            END {
+              if (preferred_id != "") {
+                print "platform=iOS Simulator,id=" preferred_id
+              } else if (fallback_id != "") {
+                print "platform=iOS Simulator,id=" fallback_id
+              }
+            }
+          ')"
+
+          if [[ -z "$DESTINATION" ]]; then
+            echo "No available simulator device found. Creating a fresh iOS simulator."
+
+            RUNTIME_ID="$(xcrun simctl list runtimes available | awk '/^iOS / { runtime = $NF } END { print runtime }')"
+            DEVICE_TYPE_ID="$(xcrun simctl list devicetypes | awk -v preferred="$SIMULATOR_NAME" '
+              $0 ~ "^" preferred " \\(" {
+                if (match($0, /\([^)]+\)$/)) {
+                  print substr($0, RSTART + 1, RLENGTH - 2)
+                  exit
+                }
+              }
+              $0 ~ /^iPhone / && fallback == "" {
+                if (match($0, /\([^)]+\)$/)) {
+                  fallback = substr($0, RSTART + 1, RLENGTH - 2)
                 }
               }
               END {
-                if (runtime != "") {
-                  print "platform=iOS Simulator,name=" name ",OS=" runtime
+                if (fallback != "") {
+                  print fallback
                 }
               }
-            '
-          )"
+            ')"
 
-          if [[ -z "$DESTINATION" ]]; then
-            echo "Unable to resolve simulator destination for $SIMULATOR_NAME"
-            cd "$PACKAGE_DIR"
-            "$DEVELOPER_DIR/usr/bin/xcodebuild" -scheme "$SCHEME" -showdestinations
-            exit 1
+            if [[ -z "$RUNTIME_ID" || -z "$DEVICE_TYPE_ID" ]]; then
+              echo "Failed to resolve simulator runtime or device type."
+              xcrun simctl list runtimes available || true
+              xcrun simctl list devicetypes || true
+              exit 1
+            fi
+
+            SIMULATOR_UDID="$(xcrun simctl create "CI-NailUI-Test" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+            DESTINATION="platform=iOS Simulator,id=$SIMULATOR_UDID"
           fi
 
           echo "IOS_DESTINATION=$DESTINATION" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- `Packages/NailUI` 변경을 감지해 package test를 실행하는 workflow를 추가했습니다.
- 설치된 `iPhone 17` simulator runtime을 자동 해석해 `xcodebuild test`를 실행하도록 구성했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `nailui-package-tests` workflow 추가
- `Packages/NailUI` 변경 감지 범위 설정
- package test 실행 경로 추가

Out of scope:
- 앱 전체 unit/UI test workflow 도입
- warning gate 정책 변경
- 앱 코드 변경

## Validation Results
- `printf 'Packages/NailUI/Package.swift\nREADME.md\n' | grep -En '^(\\.xcode-version|Packages/NailUI/|scripts/resolve-xcode-developer-dir\\.sh|\\.github/workflows/nailui-package-tests\\.yml)'`
- `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild -scheme NailUI -showdestinations`
- `DEVELOPER_DIR="$(./scripts/resolve-xcode-developer-dir.sh)" xcodebuild test -scheme NailUI -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /tmp/nailui-package-tests`
- `git diff --check`

## Risk & Rollback
- Risk: package-only PR에서도 추가 CI가 실행되어 전체 체크 시간이 늘어날 수 있습니다.
- Rollback: workflow 파일 제거로 원복 가능합니다.

## Closes
Closes #93