### PR TITLE
docs: 운영 문서 인덱스와 자산 메모 추가

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Operations Docs Index
+
+## Start Here
+
+- Preview/workaround notes: `docs/ios-preview-guide.md`
+- Warning policy and baseline workflow: `docs/ios-warning-gate.md`
+- Release checklist for social login changes: `docs/social-login-release-checklist.md`
+- Hackathon submission reference copy: `docs/hackathon-submission.md`
+
+## When To Read What
+
+- If Xcode preview behavior changes, start with `docs/ios-preview-guide.md`.
+- If CI or local builds fail because of warnings, start with `docs/ios-warning-gate.md`.
+- If a release touches Apple/Kakao/Google login flows, use `docs/social-login-release-checklist.md`.
+- If you need the current hackathon submission wording or external reference links, use `docs/hackathon-submission.md`.
+
+## Asset Note
+
+- The active app icon build setting is `ASSETCATALOG_COMPILER_APPICON_NAME = todays_nail`.
+- `NailClient/NailClient/todays_nail.icon` is tracked separately from the active `Assets.xcassets/todays_nail.appiconset`.
+- Treat `todays_nail.icon` as a retained asset source/reference bundle unless a dedicated cleanup task verifies it is safe to remove.


### PR DESCRIPTION
## Summary
- `docs/README.md`를 추가해 운영 문서 진입점을 정리했습니다.
- 각 문서의 사용 시점과 `todays_nail.icon` 관련 현재 상태를 짧게 문서화했습니다.

## Domain
client-app-ios

## Scope
In scope:
- `docs/README.md` 추가
- 운영 문서 링크 정리
- `todays_nail.icon` 자산 메모 추가

Out of scope:
- 자산 삭제
- 앱 코드 변경
- 빌드 설정 변경

## Validation Results
- `sed -n '1,220p' docs/README.md`
- `git diff --check`

## Risk & Rollback
- Risk: `todays_nail.icon` 메모는 현재 저장소 상태를 설명하는 수준이라, 실제 제거 전에는 별도 확인이 여전히 필요합니다.
- Rollback: `docs/README.md` 제거로 원복 가능합니다.

## Closes
Closes #95