### PR TITLE
[feat]: 개발용 계정 로그인 지원

### DIFF
--- a/NailClient/NailClient/App/AppViewModel.swift
+++ b/NailClient/NailClient/App/AppViewModel.swift
@@ -381,6 +381,49 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+#if DEBUG
+    func signInWithDevAccount(accountKey: String, devSecret: String, nickname: String?) async {
+        let normalizedAccountKey = accountKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedDevSecret = devSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedNickname = nickname?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedAccountKey.isEmpty else {
+            errorMessage = "개발 계정 키를 입력해주세요."
+            return
+        }
+        guard !normalizedDevSecret.isEmpty else {
+            errorMessage = "개발 로그인 코드를 입력해주세요."
+            return
+        }
+
+        errorMessage = nil
+        let traceId = AppLog.makeErrorId()
+
+        do {
+            let result = try await authService.signInWithDevAccount(
+                traceId: traceId,
+                accountKey: normalizedAccountKey,
+                devSecret: normalizedDevSecret,
+                nickname: normalizedNickname?.isEmpty == false ? normalizedNickname : nil
+            )
+            session = result.session
+            currentUser = result.user
+            if result.needsOnboarding {
+                onboardingPrefill = result.onboardingPrefill ?? prefillFromUser(result.user)
+            } else {
+                onboardingPrefill = nil
+            }
+            await syncPushTokenRegistrationIfPossible()
+            route = result.needsOnboarding ? .onboarding : .home
+            flushPendingPushRouteIfPossible()
+        } catch {
+            AppLog.auth.error("\(AppLog.prefix(traceId, "AUTH")) signInWithDevAccount failed: \(String(describing: error), privacy: .public)")
+            errorMessage = "개발용 로그인 실패. 계정 키와 코드를 확인해주세요."
+            onboardingPrefill = nil
+            route = .login
+        }
+    }
+#endif
+
     func refreshOnboardingStyleAssets(force: Bool = false) async {
         guard !Self.isRunningForPreviews else { return }
         if !force,

--- a/NailClient/NailClient/Core/Auth/AuthService.swift
+++ b/NailClient/NailClient/Core/Auth/AuthService.swift
@@ -26,6 +26,14 @@ protocol AuthServicing {
     func signInWithKakao(traceId: String) async throws -> AuthResult
     func signInWithGoogle(traceId: String) async throws -> AuthResult
     func signInWithApple(traceId: String) async throws -> AuthResult
+#if DEBUG
+    func signInWithDevAccount(
+        traceId: String,
+        accountKey: String,
+        devSecret: String,
+        nickname: String?
+    ) async throws -> AuthResult
+#endif
     func completeOnboarding(
         traceId: String,
         session: AppSession,
@@ -125,6 +133,9 @@ private enum AuthServiceUnsupportedError: LocalizedError {
     case deleteNailGeneration
     case upsertPushToken
     case deactivatePushToken
+#if DEBUG
+    case signInWithDevAccount
+#endif
 
     var errorDescription: String? {
         switch self {
@@ -140,6 +151,10 @@ private enum AuthServiceUnsupportedError: LocalizedError {
             return "푸시 토큰 등록을 지원하지 않는 인증 서비스입니다."
         case .deactivatePushToken:
             return "푸시 토큰 비활성화를 지원하지 않는 인증 서비스입니다."
+#if DEBUG
+        case .signInWithDevAccount:
+            return "개발용 로그인을 지원하지 않는 인증 서비스입니다."
+#endif
         }
     }
 }
@@ -215,6 +230,21 @@ extension AuthServicing {
     ) async throws -> (response: OKResponse, session: AppSession) {
         throw AuthServiceUnsupportedError.deactivatePushToken
     }
+
+#if DEBUG
+    func signInWithDevAccount(
+        traceId: String,
+        accountKey: String,
+        devSecret: String,
+        nickname: String?
+    ) async throws -> AuthResult {
+        _ = traceId
+        _ = accountKey
+        _ = devSecret
+        _ = nickname
+        throw AuthServiceUnsupportedError.signInWithDevAccount
+    }
+#endif
 }
 
 private enum AuthServiceTimeoutError: LocalizedError {
@@ -358,6 +388,41 @@ final class AuthService: @unchecked Sendable, AuthServicing {
             onboardingPrefill: mapOnboardingPrefill(response.onboardingPrefill)
         )
     }
+
+#if DEBUG
+    func signInWithDevAccount(
+        traceId: String,
+        accountKey: String,
+        devSecret: String,
+        nickname: String?
+    ) async throws -> AuthResult {
+        let deviceId = await ensureDeviceId()
+        let response = try await api.authDevLogin(
+            traceId: traceId,
+            accountKey: accountKey,
+            devSecret: devSecret,
+            deviceId: deviceId,
+            nickname: nickname
+        )
+
+        let normalizedAccessToken = normalizeAccessToken(response.accessToken)
+        let normalizedRefreshToken = normalizeRefreshToken(response.refreshToken)
+        let session = AppSession(accessToken: normalizedAccessToken, refreshToken: normalizedRefreshToken)
+        await writeRefreshToken(normalizedRefreshToken)
+        await updateStoredSessionMetadata(
+            accessTokenExpiresAt: response.accessTokenExpiresAt,
+            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
+            sessionID: response.sessionID
+        )
+
+        return AuthResult(
+            session: session,
+            user: response.user,
+            needsOnboarding: response.needsOnboarding,
+            onboardingPrefill: mapOnboardingPrefill(response.onboardingPrefill)
+        )
+    }
+#endif
 
     func completeOnboarding(
         traceId: String,

--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -118,9 +118,9 @@ final class EdgeAPIClient {
             path: "auth-dev-login",
             method: "POST",
             accessToken: nil,
+            headers: ["X-Dev-Auth-Secret": devSecret],
             body: AuthDevLoginRequest(
                 accountKey: accountKey,
-                devSecret: devSecret,
                 deviceId: deviceId,
                 nickname: nickname
             )
@@ -467,6 +467,7 @@ final class EdgeAPIClient {
         path: String,
         method: String,
         accessToken: String?,
+        headers: [String: String] = [:],
         body: B,
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     ) async throws -> T {
@@ -477,6 +478,7 @@ final class EdgeAPIClient {
             pathForLog: path,
             method: method,
             accessToken: accessToken,
+            headers: headers,
             body: body,
             cachePolicy: cachePolicy
         )
@@ -488,6 +490,7 @@ final class EdgeAPIClient {
         pathForLog: String,
         method: String,
         accessToken: String?,
+        headers: [String: String] = [:],
         body: B,
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     ) async throws -> T {
@@ -499,6 +502,9 @@ final class EdgeAPIClient {
         req.timeoutInterval = requestTimeout
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("2", forHTTPHeaderField: "X-Auth-API-Version")
+        for (field, value) in headers where !value.isEmpty {
+            req.setValue(value, forHTTPHeaderField: field)
+        }
 
         if let token = normalizeBearerToken(accessToken), !token.isEmpty {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -636,7 +642,6 @@ struct AuthAppleRequest: Encodable {
 #if DEBUG
 struct AuthDevLoginRequest: Encodable {
     let accountKey: String
-    let devSecret: String
     let deviceId: String
     let nickname: String?
 }

--- a/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
+++ b/NailClient/NailClient/Core/Networking/EdgeAPIClient.swift
@@ -105,6 +105,29 @@ final class EdgeAPIClient {
         )
     }
 
+#if DEBUG
+    func authDevLogin(
+        traceId: String,
+        accountKey: String,
+        devSecret: String,
+        deviceId: String,
+        nickname: String?
+    ) async throws -> AuthKakaoResponse {
+        try await request(
+            traceId: traceId,
+            path: "auth-dev-login",
+            method: "POST",
+            accessToken: nil,
+            body: AuthDevLoginRequest(
+                accountKey: accountKey,
+                devSecret: devSecret,
+                deviceId: deviceId,
+                nickname: nickname
+            )
+        )
+    }
+#endif
+
     func fetchPublicOnboardingStyles(traceId: String) async throws -> PublicOnboardingStylesResponse {
         try await request(
             traceId: traceId,
@@ -609,6 +632,15 @@ struct AuthAppleRequest: Encodable {
     let idToken: String
     let deviceId: String
 }
+
+#if DEBUG
+struct AuthDevLoginRequest: Encodable {
+    let accountKey: String
+    let devSecret: String
+    let deviceId: String
+    let nickname: String?
+}
+#endif
 
 struct AuthRefreshRequest: Encodable {
     let refreshToken: String

--- a/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
+++ b/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
@@ -12,6 +12,11 @@ struct LoginEntryView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var viewModel = LoginEntryViewModel()
+#if DEBUG
+    @State private var devAccountKey = "default"
+    @State private var devSecret = ""
+    @State private var devNickname = "iOS Dev"
+#endif
 
     var body: some View {
         ZStack {
@@ -88,6 +93,9 @@ struct LoginEntryView: View {
         VStack(spacing: 16) {
             socialSectionHeader
             socialButtons
+#if DEBUG
+            devLoginSection
+#endif
         }
         .frame(maxWidth: .infinity)
     }
@@ -122,10 +130,75 @@ struct LoginEntryView: View {
             .accessibilityIdentifier("social_sign_in_header")
     }
 
+#if DEBUG
+    private var devLoginSection: some View {
+        VStack(spacing: 10) {
+            TextField("dev account", text: $devAccountKey)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .devLoginFieldStyle(colorScheme: colorScheme)
+                .accessibilityIdentifier("dev_login_account_field")
+
+            SecureField("dev code", text: $devSecret)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .devLoginFieldStyle(colorScheme: colorScheme)
+                .accessibilityIdentifier("dev_login_secret_field")
+
+            TextField("nickname", text: $devNickname)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .devLoginFieldStyle(colorScheme: colorScheme)
+                .accessibilityIdentifier("dev_login_nickname_field")
+
+            Button {
+                Task {
+                    await appViewModel.signInWithDevAccount(
+                        accountKey: devAccountKey,
+                        devSecret: devSecret,
+                        nickname: devNickname
+                    )
+                }
+            } label: {
+                Text("개발 계정 로그인")
+                    .appTypography(size: 14, weight: .semibold)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 42)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .background(LoginDesignTokens.brandPrimary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .accessibilityIdentifier("dev_login_button")
+        }
+        .padding(.top, 8)
+    }
+#endif
+
     private func clamped(_ value: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
         Swift.max(min, Swift.min(max, value))
     }
 }
+
+#if DEBUG
+private extension View {
+    func devLoginFieldStyle(colorScheme: ColorScheme) -> some View {
+        self
+            .textFieldStyle(.plain)
+            .appTypography(size: 14, weight: .medium)
+            .foregroundStyle(colorScheme == .dark ? Color.white.opacity(0.9) : LoginDesignTokens.textMain)
+            .padding(.horizontal, 12)
+            .frame(height: 40)
+            .background(
+                colorScheme == .dark ? Color.white.opacity(0.08) : Color.white.opacity(0.74),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(LoginDesignTokens.borderLight.opacity(colorScheme == .dark ? 0.3 : 0.8), lineWidth: 1)
+            }
+    }
+}
+#endif
 
 #if DEBUG
 #Preview {

--- a/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
+++ b/NailClient/NailClient/Features/Login/Views/LoginEntryView.swift
@@ -14,7 +14,7 @@ struct LoginEntryView: View {
     @StateObject private var viewModel = LoginEntryViewModel()
 #if DEBUG
     @State private var devAccountKey = "default"
-    @State private var devSecret = ""
+    @State private var devSecret = ProcessInfo.processInfo.environment["DEV_AUTH_SECRET"] ?? ""
     @State private var devNickname = "iOS Dev"
 #endif
 
@@ -23,9 +23,14 @@ struct LoginEntryView: View {
             LoginBackgroundView()
 
             GeometryReader { proxy in
+#if DEBUG
+                let topSpacing = clamped(proxy.safeAreaInsets.top + (proxy.size.height * 0.04), min: 12, max: 72)
+                let brandToActionSpacing = clamped(proxy.size.height * 0.08, min: 4, max: 56)
+#else
                 let topSpacing = clamped(proxy.safeAreaInsets.top + (proxy.size.height * 1), min: 12, max: 160)
                 // SNS 섹션과 로고 영역 간격을 더 촘촘하게 유지한다.
                 let brandToActionSpacing = clamped(proxy.size.height * 0.4, min: 4, max: 150)
+#endif
                 let bottomSpacing = clamped(proxy.safeAreaInsets.bottom + (proxy.size.height * 0.08), min: 12, max: 48)
 
                 VStack(spacing: 0) {

--- a/NailClient/NailClientTests/App/NailClientTests.swift
+++ b/NailClient/NailClientTests/App/NailClientTests.swift
@@ -444,6 +444,86 @@ struct NailClientTests {
         #expect(viewModel.errorMessage?.contains("Apple 로그인 실패") == true)
     }
 
+#if DEBUG
+    @Test
+    func signInWithDevAccount_성공시_홈으로이동한다() async {
+        let user = AppTestFixtures.makeUser(nickname: "dev-user", profileImageURL: nil)
+        let result = AppTestFixtures.makeAuthResult(
+            session: AppTestFixtures.makeSession(
+                accessToken: "dev-access",
+                refreshToken: "dev-refresh"
+            ),
+            user: user,
+            needsOnboarding: false
+        )
+
+        let authService = MockAuthService(
+            behavior: .immediate(nil),
+            signInWithDevAccountResult: .success(result)
+        )
+        let viewModel = AppViewModel(authService: authService)
+
+        await viewModel.signInWithDevAccount(
+            accountKey: " default ",
+            devSecret: " dev-code ",
+            nickname: " dev-user "
+        )
+
+        #expect(viewModel.route == .home)
+        #expect(viewModel.currentUser?.id == user.id)
+        #expect(viewModel.session?.accessToken == "dev-access")
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func signInWithDevAccount_실패시_로그인으로복귀한다() async {
+        let authService = MockAuthService(
+            behavior: .immediate(nil),
+            signInWithDevAccountResult: .failure(
+                EdgeAPIError(statusCode: 401, message: "dev failed", code: "AUTH_DEV_SECRET_INVALID", errorId: "D-1")
+            )
+        )
+        let viewModel = AppViewModel(authService: authService)
+
+        await viewModel.signInWithDevAccount(
+            accountKey: "default",
+            devSecret: "wrong-code",
+            nickname: nil
+        )
+
+        #expect(viewModel.route == .login)
+        #expect(viewModel.currentUser == nil)
+        #expect(viewModel.session == nil)
+        #expect(viewModel.errorMessage?.contains("개발용 로그인 실패") == true)
+    }
+
+    @Test
+    func signInWithDevAccount_필수입력누락시_로그인요청전_오류를표시한다() async {
+        let authService = MockAuthService(behavior: .immediate(nil))
+        let viewModel = AppViewModel(authService: authService)
+
+        await viewModel.signInWithDevAccount(
+            accountKey: " ",
+            devSecret: "dev-code",
+            nickname: nil
+        )
+
+        #expect(viewModel.route == .login)
+        #expect(viewModel.session == nil)
+        #expect(viewModel.errorMessage == "개발 계정 키를 입력해주세요.")
+
+        await viewModel.signInWithDevAccount(
+            accountKey: "default",
+            devSecret: " ",
+            nickname: nil
+        )
+
+        #expect(viewModel.route == .login)
+        #expect(viewModel.session == nil)
+        #expect(viewModel.errorMessage == "개발 로그인 코드를 입력해주세요.")
+    }
+#endif
+
     @Test
     func refreshPushAuthorizationState_권한상태를갱신한다() async {
         let pushManager = MockPushNotificationManager(

--- a/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
+++ b/NailClient/NailClientTests/TestSupport/Spies/AuthServiceTestDoubles.swift
@@ -36,6 +36,7 @@ actor MockAuthService: AuthServicing {
     let behavior: MockAutoLoginBehavior
     let signInWithGoogleResult: Result<AuthResult, Error>?
     let signInWithAppleResult: Result<AuthResult, Error>?
+    let signInWithDevAccountResult: Result<AuthResult, Error>?
     let updateMyProfileBehavior: MockUpdateMyProfileBehavior
     let deleteMyAccountBehavior: MockDeleteMyAccountBehavior
     let completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior
@@ -48,6 +49,7 @@ actor MockAuthService: AuthServicing {
         behavior: MockAutoLoginBehavior,
         signInWithGoogleResult: Result<AuthResult, Error>? = nil,
         signInWithAppleResult: Result<AuthResult, Error>? = nil,
+        signInWithDevAccountResult: Result<AuthResult, Error>? = nil,
         updateMyProfileBehavior: MockUpdateMyProfileBehavior = .unsupported,
         deleteMyAccountBehavior: MockDeleteMyAccountBehavior = .unsupported,
         completedNailGenerationListBehavior: MockCompletedNailGenerationListBehavior = .unsupported,
@@ -56,6 +58,7 @@ actor MockAuthService: AuthServicing {
         self.behavior = behavior
         self.signInWithGoogleResult = signInWithGoogleResult
         self.signInWithAppleResult = signInWithAppleResult
+        self.signInWithDevAccountResult = signInWithDevAccountResult
         self.updateMyProfileBehavior = updateMyProfileBehavior
         self.deleteMyAccountBehavior = deleteMyAccountBehavior
         self.completedNailGenerationListBehavior = completedNailGenerationListBehavior
@@ -95,6 +98,24 @@ actor MockAuthService: AuthServicing {
         }
         return try signInWithAppleResult.get()
     }
+
+#if DEBUG
+    func signInWithDevAccount(
+        traceId: String,
+        accountKey: String,
+        devSecret: String,
+        nickname: String?
+    ) async throws -> AuthResult {
+        _ = traceId
+        _ = accountKey
+        _ = devSecret
+        _ = nickname
+        guard let signInWithDevAccountResult else {
+            throw MockAuthError.unsupported
+        }
+        return try signInWithDevAccountResult.get()
+    }
+#endif
 
     func completeOnboarding(
         traceId: String,

--- a/NailClient/NailClientUITests/Flows/NailClientUITests.swift
+++ b/NailClient/NailClientUITests/Flows/NailClientUITests.swift
@@ -11,6 +11,7 @@ final class NailClientUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
     }
 
     override func tearDownWithError() throws {
@@ -44,6 +45,24 @@ final class NailClientUITests: XCTestCase {
 
         XCTAssertEqual(appleButton.frame.minY, kakaoButton.frame.minY, accuracy: 2)
         XCTAssertEqual(appleButton.frame.minY, googleButton.frame.minY, accuracy: 2)
+    }
+
+    @MainActor
+    func testDebugDevLoginControlsAreUsableOnLoginScreen() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--uitesting-route-login")
+        app.launch()
+
+        let accountField = app.textFields["dev_login_account_field"]
+        let secretField = app.secureTextFields["dev_login_secret_field"]
+        let nicknameField = app.textFields["dev_login_nickname_field"]
+        let loginButton = app.buttons["dev_login_button"]
+
+        XCTAssertTrue(accountField.waitForExistence(timeout: 5))
+        XCTAssertTrue(secretField.waitForExistence(timeout: 5))
+        XCTAssertTrue(nicknameField.waitForExistence(timeout: 5))
+        XCTAssertTrue(loginButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(loginButton.isHittable)
     }
 
     @MainActor

--- a/scripts/ios-warning-gate.sh
+++ b/scripts/ios-warning-gate.sh
@@ -33,6 +33,9 @@ ALL_WARNINGS="$TMP_DIR/all_warnings.txt"
 APP_WARNINGS="$TMP_DIR/app_warnings.txt"
 TOOL_WARNINGS="$TMP_DIR/tool_warnings.txt"
 UNKNOWN_TOOL_WARNINGS="$TMP_DIR/unknown_tool_warnings.txt"
+COMMON_BUILD_SETTINGS=(
+  COMPILER_INDEX_STORE_ENABLE=NO
+)
 
 mkdir -p "$RELEASE_DERIVED_DATA_PATH" "$DEBUG_DERIVED_DATA_PATH"
 
@@ -44,7 +47,7 @@ resolve_developer_dir() {
 }
 
 run_release_build() {
-  echo "[warning-gate] Release clean build..."
+  echo "[warning-gate] Release build..."
   echo "[warning-gate] Release derivedDataPath: $RELEASE_DERIVED_DATA_PATH"
   DEVELOPER_DIR="$DEVELOPER_DIR_VALUE" \
     xcodebuild \
@@ -54,16 +57,17 @@ run_release_build() {
       -destination 'generic/platform=iOS' \
       -derivedDataPath "$RELEASE_DERIVED_DATA_PATH" \
       CODE_SIGNING_ALLOWED=NO \
-      clean build >"$RELEASE_LOG" 2>&1 &
+      "${COMMON_BUILD_SETTINGS[@]}" \
+      build >"$RELEASE_LOG" 2>&1 &
   local pid=$!
   while kill -0 "$pid" 2>/dev/null; do
     sleep 20
     if kill -0 "$pid" 2>/dev/null; then
-      echo "[warning-gate] Release clean build 진행 중..."
+      echo "[warning-gate] Release build 진행 중..."
     fi
   done
   if ! wait "$pid"; then
-    echo "[warning-gate] Release clean build 실패. 최근 로그:"
+    echo "[warning-gate] Release build 실패. 최근 로그:"
     tail -n 120 "$RELEASE_LOG" || true
     return 1
   fi
@@ -79,6 +83,7 @@ run_debug_build() {
       -configuration Debug \
       -sdk iphonesimulator \
       -derivedDataPath "$DEBUG_DERIVED_DATA_PATH" \
+      "${COMMON_BUILD_SETTINGS[@]}" \
       build >"$DEBUG_LOG" 2>&1 &
   local pid=$!
   while kill -0 "$pid" 2>/dev/null; do


### PR DESCRIPTION
## Summary
- Add DEBUG-only dev account login UI to the login entry screen.
- Wire dev login through `EdgeAPIClient`, `AuthService`, and `AppViewModel`.
- Send the dev auth secret via `X-Dev-Auth-Secret` instead of JSON body.
- Support local Debug verification by prefilling `DEV_AUTH_SECRET` from the app launch environment when present.
- Trim warning-gate CI overhead by removing redundant clean work and disabling index-store generation.

## Scope
- In scope: iOS debug-only dev login UI/API/auth flow, AppViewModel tests, UI coverage for dev login controls, and a small warning-gate script optimization.
- In scope: shared-schema contract references for the dev auth endpoint.
- Out of scope: production enablement, production secrets, DB cleanup, and image model migration.
- Out of scope: enabling dev login outside staging.

## Validation Results
- `NailClientTests`: 102 passed on iPhone 17 simulator.
- `NailClientUITests`: passed on iPhone 17 simulator, about 383s locally.
- `testDebugDevLoginControlsAreUsableOnLoginScreen`: passed after portrait stabilization.
- Debug build/install/run on iPhone 17 simulator: passed.
- Staging API smoke test after shared-schema #38 deploy: wrong secret 401, valid dev login 200, `users-me` 200, `auth-refresh` 200.
- iOS actual staging login: `accountKey=default`, staging dev secret via launch environment, nickname `iOS Dev` -> home route success.
- Auto-login/session persistence: app restart without secret env -> home route success.
- Logout: profile logout -> login screen success.

## Risk & Rollback
- Dev login UI is compiled only in DEBUG builds.
- Staging dev secret is configured only in the staging Supabase project and is not included in repo, PR, or logs.
- Related shared-schema issue: https://github.com/todays-nail/shared-schema/issues/37
- Related shared-schema PR: https://github.com/todays-nail/shared-schema/pull/38
- App impact classification: app change required.

## Closes
Closes #97
